### PR TITLE
Fix urlEncode to zero-pad hex bytes

### DIFF
--- a/utils/launcher.hpp
+++ b/utils/launcher.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <chrono>
 #include <sstream>
+#include <iomanip>
 
 #include "logging.hpp"
 #include "notifications.h"
@@ -12,15 +13,15 @@ using namespace std;
 using namespace std::chrono;
 
 static string urlEncode(const string &s) {
-	ostringstream out;
-	out << hex << uppercase;
-	for (unsigned char c: s) {
-		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
-			out << c;
-		else
-			out << '%' << setw(2) << static_cast<int>(c);
-	}
-	return out.str();
+        ostringstream out;
+        out << hex << uppercase;
+        for (unsigned char c: s) {
+                if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+                        out << c;
+                else
+                        out << '%' << setw(2) << setfill('0') << static_cast<int>(c);
+        }
+        return out.str();
 }
 
 inline HANDLE startRoblox(uint64_t placeId, const string &jobId, const string &cookie) {


### PR DESCRIPTION
## Summary
- ensure urlEncode pads encoded bytes with `0`
- include `<iomanip>` for `std::setw`/`setfill`

## Testing
- `g++ -std=c++17 -c test.cpp` *(fails: `cpr/cpr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f75f170a8832f92be619de95e6c7e