### PR TITLE
Add GetLogs to console

### DIFF
--- a/components/console/console_tab.cpp
+++ b/components/console/console_tab.cpp
@@ -152,4 +152,9 @@ namespace Console {
         EndChild();
         PopStyleVar(1);
     }
+
+    std::vector<std::string> GetLogs() {
+        std::lock_guard<std::mutex> lock(g_logMutex);
+        return g_logMessages;
+    }
 }


### PR DESCRIPTION
## Summary
- implement `Console::GetLogs` in `console_tab.cpp`
- expose log access under mutex lock

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by `cpr`)*

------
https://chatgpt.com/codex/tasks/task_e_683f7d95115c832fa5bdb3175057ddd2