### PR TITLE
Handle banned accounts in UI

### DIFF
--- a/utils/roblox_api.h
+++ b/utils/roblox_api.h
@@ -27,6 +27,9 @@ static ImVec4 getStatusColor(string statusCode) {
     if (statusCode == "Invisible") {
         return ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
     }
+    if (statusCode == "Banned") {
+        return ImVec4(1.0f, 0.3f, 0.3f, 1.0f);
+    }
     return ImVec4(0.8f, 0.8f, 0.8f, 1.0f);
 }
 


### PR DESCRIPTION
## Summary
- show banned account status in red

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_683f7f0dcff4832fa26c028e59e16b39