### PR TITLE
Add voice chat status column

### DIFF
--- a/components/accounts/accounts_tab.cpp
+++ b/components/accounts/accounts_tab.cpp
@@ -31,7 +31,7 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
         TableSetupColumn("Username", ImGuiTableColumnFlags_WidthStretch);
         TableSetupColumn("UserID", ImGuiTableColumnFlags_WidthFixed, 100.0f);
         TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 100.0f);
-        TableSetupColumn("Voice", ImGuiTableColumnFlags_WidthFixed, 100.0f);
+        TableSetupColumn("Voice", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_DefaultHide, 100.0f);
         TableSetupColumn("Note", ImGuiTableColumnFlags_WidthStretch);
         TableSetupScrollFreeze(0, 1);
 

--- a/components/accounts/accounts_tab.cpp
+++ b/components/accounts/accounts_tab.cpp
@@ -16,7 +16,7 @@
 using namespace ImGui;
 
 void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *table_id, float table_height) {
-    constexpr int column_count = 5;
+    constexpr int column_count = 6;
     ImGuiTableFlags table_flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable |
                                   ImGuiTableFlags_ScrollY | ImGuiTableFlags_Hideable | ImGuiTableFlags_Reorderable |
                                   ImGuiTableFlags_ContextMenuInBody;
@@ -30,6 +30,7 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
         TableSetupColumn("Username", ImGuiTableColumnFlags_WidthStretch);
         TableSetupColumn("UserID", ImGuiTableColumnFlags_WidthFixed, 100.0f);
         TableSetupColumn("Status", ImGuiTableColumnFlags_WidthFixed, 100.0f);
+        TableSetupColumn("Voice", ImGuiTableColumnFlags_WidthFixed, 100.0f);
         TableSetupColumn("Note", ImGuiTableColumnFlags_WidthStretch);
         TableSetupScrollFreeze(0, 1);
 
@@ -42,6 +43,8 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
         TextUnformatted("UserID");
         TableNextColumn();
         TextUnformatted("Status");
+        TableNextColumn();
+        TextUnformatted("Voice");
         TableNextColumn();
         TextUnformatted("Note");
 
@@ -115,6 +118,8 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
 
             ImVec4 statusColor = getStatusColor(account.status);
             render_centered_text_in_cell(account.status.c_str(), &statusColor);
+
+            render_centered_text_in_cell(account.voiceStatus.c_str());
 
             render_centered_text_in_cell(account.note.c_str());
 

--- a/components/accounts/accounts_tab.cpp
+++ b/components/accounts/accounts_tab.cpp
@@ -10,6 +10,7 @@
 
 #include "../../utils/roblox_api.h"
 #include "../components.h"
+#include "../../utils/time_utils.h"
 #include "../../ui.h"
 #include "../data.h"
 
@@ -119,7 +120,17 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
             ImVec4 statusColor = getStatusColor(account.status);
             render_centered_text_in_cell(account.status.c_str(), &statusColor);
 
-            render_centered_text_in_cell(account.voiceStatus.c_str());
+            TableNextColumn();
+            float voice_y = GetCursorPosY();
+            SetCursorPosY(voice_y + vertical_padding);
+            TextUnformatted(account.voiceStatus.c_str());
+            if (account.voiceStatus == "Banned" && account.voiceBanExpiry > 0 && IsItemHovered()) {
+                BeginTooltip();
+                string timeStr = formatRelativeFuture(account.voiceBanExpiry);
+                TextUnformatted(timeStr.c_str());
+                EndTooltip();
+            }
+            SetCursorPosY(voice_y + row_interaction_height);
 
             render_centered_text_in_cell(account.note.c_str());
 

--- a/components/data.cpp
+++ b/components/data.cpp
@@ -99,6 +99,7 @@ namespace Data {
             account.userId = item.value("userId", "");
             account.status = item.value("status", "");
             account.voiceStatus = item.value("voiceStatus", "");
+            account.voiceBanExpiry = item.value("voiceBanExpiry", 0);
             account.note = item.value("note", "");
             account.isFavorite = item.value("isFavorite", false);
 
@@ -163,6 +164,7 @@ namespace Data {
                 {"userId", account.userId},
                 {"status", account.status},
                 {"voiceStatus", account.voiceStatus},
+                {"voiceBanExpiry", account.voiceBanExpiry},
                 {"note", account.note},
                 {"encryptedCookie", b64EncryptedCookie},
                 {"isFavorite", account.isFavorite}

--- a/components/data.cpp
+++ b/components/data.cpp
@@ -98,6 +98,7 @@ namespace Data {
             account.username = item.value("username", "");
             account.userId = item.value("userId", "");
             account.status = item.value("status", "");
+            account.voiceStatus = item.value("voiceStatus", "");
             account.note = item.value("note", "");
             account.isFavorite = item.value("isFavorite", false);
 
@@ -161,6 +162,7 @@ namespace Data {
                 {"username", account.username},
                 {"userId", account.userId},
                 {"status", account.status},
+                {"voiceStatus", account.voiceStatus},
                 {"note", account.note},
                 {"encryptedCookie", b64EncryptedCookie},
                 {"isFavorite", account.isFavorite}

--- a/components/data.h
+++ b/components/data.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <set>
 #include <array>
+#include <ctime>
 #include <imgui.h>
 
 struct AccountData {
@@ -14,6 +15,7 @@ struct AccountData {
     std::string userId;
     std::string status;
     std::string voiceStatus;
+    time_t voiceBanExpiry = 0;
     std::string note;
     std::string cookie;
     bool isFavorite = false;

--- a/components/data.h
+++ b/components/data.h
@@ -13,6 +13,7 @@ struct AccountData {
     std::string username;
     std::string userId;
     std::string status;
+    std::string voiceStatus;
     std::string note;
     std::string cookie;
     bool isFavorite = false;

--- a/components/menu.cpp
+++ b/components/menu.cpp
@@ -107,6 +107,7 @@ bool RenderMainMenu() {
                     LOG_INFO("Refreshing account statuses...");
                     for (auto &acct: g_accounts) {
                         acct.status = RobloxApi::getPresence(acct.cookie, stoull(acct.userId));
+                        acct.voiceStatus = RobloxApi::getVoiceChatStatus(acct.cookie);
                     }
                     Data::SaveAccounts();
                     LOG_INFO("Refreshed account statuses");
@@ -140,6 +141,7 @@ bool RenderMainMenu() {
                             string username = RobloxApi::getUsername(cookie);
                             string displayName = RobloxApi::getDisplayName(cookie);
                             string presence = RobloxApi::getPresence(cookie, uid);
+                            string voice = RobloxApi::getVoiceChatStatus(cookie);
 
                             AccountData newAcct;
                             newAcct.id = nextId;
@@ -148,6 +150,7 @@ bool RenderMainMenu() {
                             newAcct.username = move(username);
                             newAcct.displayName = move(displayName);
                             newAcct.status = move(presence);
+                            newAcct.voiceStatus = move(voice);
                             newAcct.note = "";
                             newAcct.isFavorite = false;
 

--- a/components/menu.cpp
+++ b/components/menu.cpp
@@ -107,7 +107,9 @@ bool RenderMainMenu() {
                     LOG_INFO("Refreshing account statuses...");
                     for (auto &acct: g_accounts) {
                         acct.status = RobloxApi::getPresence(acct.cookie, stoull(acct.userId));
-                        acct.voiceStatus = RobloxApi::getVoiceChatStatus(acct.cookie);
+                        auto vs = RobloxApi::getVoiceChatStatus(acct.cookie);
+                        acct.voiceStatus = vs.status;
+                        acct.voiceBanExpiry = vs.bannedUntil;
                     }
                     Data::SaveAccounts();
                     LOG_INFO("Refreshed account statuses");
@@ -141,7 +143,7 @@ bool RenderMainMenu() {
                             string username = RobloxApi::getUsername(cookie);
                             string displayName = RobloxApi::getDisplayName(cookie);
                             string presence = RobloxApi::getPresence(cookie, uid);
-                            string voice = RobloxApi::getVoiceChatStatus(cookie);
+                            auto vs = RobloxApi::getVoiceChatStatus(cookie);
 
                             AccountData newAcct;
                             newAcct.id = nextId;
@@ -150,7 +152,8 @@ bool RenderMainMenu() {
                             newAcct.username = move(username);
                             newAcct.displayName = move(displayName);
                             newAcct.status = move(presence);
-                            newAcct.voiceStatus = move(voice);
+                            newAcct.voiceStatus = vs.status;
+                            newAcct.voiceBanExpiry = vs.bannedUntil;
                             newAcct.note = "";
                             newAcct.isFavorite = false;
 

--- a/utils/roblox_api.h
+++ b/utils/roblox_api.h
@@ -372,6 +372,36 @@ namespace RobloxApi {
         }
     }
 
+    static string getVoiceChatStatus(const string &cookie) {
+        LOG_INFO("Fetching voice chat settings");
+        auto resp = HttpClient::get(
+            "https://voice.roblox.com/v1/settings",
+            {{"Cookie", ".ROBLOSECURITY=" + cookie}}
+        );
+
+        if (resp.status_code != 200) {
+            LOG_INFO("Failed to fetch voice settings: HTTP " +
+                     to_string(resp.status_code));
+            if (resp.status_code == 403)
+                return "Banned";
+            return "Unknown";
+        }
+
+        auto j = HttpClient::decode(resp);
+        bool banned = j.value("isBanned", false);
+        bool enabled = j.value("isVoiceEnabled", false);
+        bool eligible = j.value("isUserEligible", false);
+        bool opted = j.value("isUserOptIn", false);
+
+        if (banned)
+            return "Banned";
+        if (enabled || opted)
+            return "Enabled";
+        if (eligible)
+            return "Disabled";
+        return "Not Eligible";
+    }
+
     struct FriendDetail {
         uint64_t id = 0;
         string username;

--- a/utils/time_utils.h
+++ b/utils/time_utils.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <string>
+#include <chrono>
+#include <sstream>
+
+inline std::string formatRelativeFuture(time_t timestamp) {
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    auto future = system_clock::from_time_t(timestamp);
+    auto diff = duration_cast<seconds>(future - now).count();
+    if (diff <= 0)
+        return "now";
+
+    long long years = diff / 31556952LL; diff %= 31556952LL;
+    long long months = diff / 2629746LL; diff %= 2629746LL;
+    long long days = diff / 86400LL; diff %= 86400LL;
+    long long hours = diff / 3600LL; diff %= 3600LL;
+    long long minutes = diff / 60LL; diff %= 60LL;
+    long long seconds = diff;
+
+    std::ostringstream ss;
+    if (years > 0)
+        ss << years << " year" << (years == 1 ? "" : "s");
+    else if (months > 0)
+        ss << months << " month" << (months == 1 ? "" : "s");
+    else if (days > 0)
+        ss << days << " day" << (days == 1 ? "" : "s");
+    else if (hours > 0)
+        ss << hours << " hour" << (hours == 1 ? "" : "s");
+    else if (minutes > 0)
+        ss << minutes << " minute" << (minutes == 1 ? "" : "s");
+    else
+        ss << seconds << " second" << (seconds == 1 ? "" : "s");
+    return ss.str();
+}


### PR DESCRIPTION
## Summary
- track voice chat status for each account
- show voice chat status in accounts table
- fetch voice status from Roblox API when adding or refreshing accounts

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_683f8064b1e4832fab4e8ae4ece3cd24