### PR TITLE
Enable copy context menus in tables

### DIFF
--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -186,11 +186,19 @@ void RenderFriendsTab() {
                     TableSetColumnIndex(1);
                     Indent(desiredTextIndent);
                     Spacing();
+                    PushID(label);
                     if (isWrapped) {
                         TextWrapped("%s", value.c_str());
                     } else {
                         TextUnformatted(value.c_str());
                     }
+                    if (BeginPopupContextItem("CopyFriendValue")) {
+                        if (MenuItem("Copy")) {
+                            SetClipboardText(value.c_str());
+                        }
+                        EndPopup();
+                    }
+                    PopID();
                     Spacing();
                     Unindent(desiredTextIndent);
                 };
@@ -238,10 +246,19 @@ void RenderFriendsTab() {
                     descChildHeight = minDescHeight;
                 }
 
+                const string descStr = D.description.empty() ? "(No description)" : D.description;
+                PushID("FriendDesc");
                 BeginChild("##FriendDescScroll", ImVec2(0, descChildHeight - 4), false,
                            ImGuiWindowFlags_HorizontalScrollbar);
-                TextWrapped("%s", D.description.empty() ? "(No description)" : D.description.c_str());
+                TextWrapped("%s", descStr.c_str());
+                if (BeginPopupContextItem("CopyFriendDesc")) {
+                    if (MenuItem("Copy")) {
+                        SetClipboardText(descStr.c_str());
+                    }
+                    EndPopup();
+                }
                 EndChild();
+                PopID();
 
                 Spacing();
                 Unindent(desiredTextIndent);

--- a/components/games/games_tab.cpp
+++ b/components/games/games_tab.cpp
@@ -241,7 +241,15 @@ static void RenderGameDetailsPanel(float panelWidth, float availableHeight) {
                 TableSetColumnIndex(1);
                 Indent(desiredTextIndent);
                 Spacing();
+                PushID(label);
                 TextWrapped("%s", valueString.c_str());
+                if (BeginPopupContextItem("CopyGameValue")) {
+                    if (MenuItem("Copy")) {
+                        SetClipboardText(valueString.c_str());
+                    }
+                    EndPopup();
+                }
+                PopID();
                 Spacing();
                 Unindent(desiredTextIndent);
             };
@@ -288,10 +296,19 @@ static void RenderGameDetailsPanel(float panelWidth, float availableHeight) {
                 descChildHeight = minDescHeight;
             }
 
+            const string descStr = detailInfo.description;
+            PushID("GameDesc");
             BeginChild("##DescScroll", ImVec2(0, descChildHeight - 4), false,
                        ImGuiWindowFlags_HorizontalScrollbar);
-            TextWrapped("%s", detailInfo.description.c_str());
+            TextWrapped("%s", descStr.c_str());
+            if (BeginPopupContextItem("CopyGameDesc")) {
+                if (MenuItem("Copy")) {
+                    SetClipboardText(descStr.c_str());
+                }
+                EndPopup();
+            }
             EndChild();
+            PopID();
 
             Spacing();
             Unindent(desiredTextIndent);

--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -121,20 +121,56 @@ static void startLogWatcher() {
 
 static void DisplayOptionalText(const char *label, const string &value) {
     if (!value.empty()) {
+        PushID(label);
         Text("%s: %s", label, value.c_str());
+        if (BeginPopupContextItem("CopyHistoryValue")) {
+            if (MenuItem("Copy")) {
+                SetClipboardText(value.c_str());
+            }
+            EndPopup();
+        }
+        PopID();
     }
 }
 
 static void DisplayLogDetails(const LogInfo &logInfo) {
+    PushID("file");
     Text("File: %s", logInfo.fileName.c_str());
-    Text("Time: %s", friendlyTimestamp(logInfo.timestamp).c_str());
+    if (BeginPopupContextItem("CopyHistoryValue")) {
+        if (MenuItem("Copy")) {
+            SetClipboardText(logInfo.fileName.c_str());
+        }
+        EndPopup();
+    }
+    PopID();
+
+    string timeStr = friendlyTimestamp(logInfo.timestamp);
+    PushID("time");
+    Text("Time: %s", timeStr.c_str());
+    if (BeginPopupContextItem("CopyHistoryValue")) {
+        if (MenuItem("Copy")) {
+            SetClipboardText(timeStr.c_str());
+        }
+        EndPopup();
+    }
+    PopID();
     DisplayOptionalText("Version", logInfo.version);
     DisplayOptionalText("Channel", logInfo.channel);
     DisplayOptionalText("Place ID", logInfo.placeId);
     DisplayOptionalText("Job ID", logInfo.jobId);
     DisplayOptionalText("Universe ID", logInfo.universeId);
-    if (!logInfo.serverIp.empty())
-        Text("Server: %s:%s", logInfo.serverIp.c_str(), logInfo.serverPort.c_str());
+    if (!logInfo.serverIp.empty()) {
+        string serverStr = logInfo.serverIp + ":" + logInfo.serverPort;
+        PushID("server");
+        Text("Server: %s", serverStr.c_str());
+        if (BeginPopupContextItem("CopyHistoryValue")) {
+            if (MenuItem("Copy")) {
+                SetClipboardText(serverStr.c_str());
+            }
+            EndPopup();
+        }
+        PopID();
+    }
     DisplayOptionalText("User ID", logInfo.userId);
 }
 


### PR DESCRIPTION
## Summary
- allow copying data values from the Friends, Games, and History tabs via right-click context menus

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8abc7c78832f95ca0a2dab3ec3f2