### PR TITLE
Add friend requests from Friends tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 ### Viewing Friends
 
 Select any saved account and navigate to the friends tab. The results will be automatically populated.
-Use the **Add Friend** button to send a request by username or user ID.
+Use the **Add Friend** button (next to Refresh) to send a request by username or user ID.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Account Management** - Add and securely save account cookies for multiple Roblox accounts
 - **Quick Join** - Join games directly using JobID or PlaceID
 - **Friends List** - View friends list for each saved account
+- **Add Friends** - Send friend requests right from the Friends tab
 - **Server Browser** - Browse active servers for any Roblox game
 - **Game Search** - Search and discover Roblox games
 - **Log Parser** - Converts Roblox log files into human-readable format
@@ -40,6 +41,7 @@
 ### Viewing Friends
 
 Select any saved account and navigate to the friends tab. The results will be automatically populated.
+Use the **Add Friend** button to send a request by username or user ID.
 
 ---
 

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -113,12 +113,16 @@ void RenderFriendsTab() {
                     } else {
                         uid = RobloxApi::getUserIdFromUsername(input);
                     }
-                    bool ok = RobloxApi::sendFriendRequest(to_string(uid), cookie);
-                    if (ok)
+                    string resp;
+                    bool ok = RobloxApi::sendFriendRequest(to_string(uid), cookie, &resp);
+                    if (ok) {
                         Status::Set("Friend request sent");
-                    else
+                    } else {
+                        cerr << "Friend request failed: " << resp << "\n";
                         Status::Set("Friend request failed");
+                    }
                 } catch (const exception &e) {
+                    cerr << "Friend request exception: " << e.what() << "\n";
                     Status::Set("Friend request failed");
                 }
                 s_addFriendLoading = false;

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -100,15 +100,16 @@ void RenderFriendsTab() {
     EndDisabled();
 
     if (s_openAddFriendPopup) {
-        OpenPopup("AddFriendPopup");
+        OpenPopup("Add Friend");
         s_openAddFriendPopup = false;
     }
-    if (BeginPopupModal("AddFriendPopup", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+    if (BeginPopupModal("Add Friend", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
         InputTextWithHint("##AddFriendUser", "Username or ID", s_addFriendBuffer, sizeof(s_addFriendBuffer));
         if (s_addFriendLoading.load()) {
             SameLine();
             TextUnformatted("Sending...");
         }
+        Spacing();
         if (Button("Send") && s_addFriendBuffer[0] != '\0' && !s_addFriendLoading.load()) {
             string input = trim_copy(s_addFriendBuffer);
             s_addFriendLoading = true;
@@ -116,7 +117,7 @@ void RenderFriendsTab() {
                 try {
                     uint64_t uid = 0;
                     if (input.empty()) throw runtime_error("Username not provided");
-                    if (all_of(input.begin(), input.end(), [](unsigned char c){ return std::isdigit(c); })) {
+                    if (all_of(input.begin(), input.end(), [](unsigned char c) { return std::isdigit(c); })) {
                         uid = stoull(input);
                     } else {
                         uid = RobloxApi::getUserIdFromUsername(input);
@@ -124,15 +125,15 @@ void RenderFriendsTab() {
                     string resp;
                     bool ok = RobloxApi::sendFriendRequest(to_string(uid), cookie, &resp);
                     if (ok) {
-                        Status::Set("Friend request sent");
+                        LOG_INFO("Friend request sent");
                         cerr << "Friend request response: " << resp << "\n";
                     } else {
                         cerr << "Friend request failed: " << resp << "\n";
-                        Status::Set("Friend request failed");
+                        LOG_INFO("Friend request failed");
                     }
                 } catch (const exception &e) {
                     cerr << "Friend request exception: " << e.what() << "\n";
-                    Status::Set(e.what());
+                    LOG_INFO(e.what());
                 }
                 s_addFriendLoading = false;
             });

--- a/utils/roblox_api.h
+++ b/utils/roblox_api.h
@@ -561,8 +561,7 @@ namespace RobloxApi {
         }
 
         nlohmann::json body = {
-            {"friendshipOriginSourceType", 0},
-            {"senderNickname", ""}
+            {"friendshipOriginSourceType", 0}
         };
 
         auto resp = HttpClient::post(
@@ -584,7 +583,9 @@ namespace RobloxApi {
 
         auto j = HttpClient::decode(resp);
         bool success = j.value("success", false);
-        if (!success) {
+        if (success) {
+            cerr << "friend request success: " << resp.text << "\n";
+        } else {
             cerr << "friend request API failure: " << resp.text << "\n";
         }
         return success;


### PR DESCRIPTION
## Summary
- support friend requests in Roblox API wrapper
- add "Add Friend" button with modal popup
- document new Add Friend capability

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_e_683f923bc1e4832faddd7f8ee00d1e4f