### PR TITLE
Add modal popups for account checks

### DIFF
--- a/components/accounts/accounts_join_ui.cpp
+++ b/components/accounts/accounts_join_ui.cpp
@@ -12,6 +12,7 @@
 #include "../../utils/launcher.hpp"
 #include "../../utils/status.h"
 #include "../../utils/logging.hpp"
+#include "../../utils/modal_popup.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -51,9 +52,12 @@ void RenderJoinOptions() {
 		                  IM_ARRAYSIZE(join_value_buf));
 	}
 
-	Separator();
-	if (Button(" \xEF\x8B\xB6  Join ")) {
-		for (int id: g_selectedAccountIds) {
+    Separator();
+    if (Button(" \xEF\x8B\xB6  Join ")) {
+            if (g_selectedAccountIds.empty()) {
+                    ModalPopup::Add("Select an account first.");
+            } else {
+                    for (int id: g_selectedAccountIds) {
 			auto it = find_if(g_accounts.begin(), g_accounts.end(),
 			                  [id](auto &a) {
 				                  return a.id == id;
@@ -130,3 +134,4 @@ void RenderJoinOptions() {
 		}
 	}
 }
+

--- a/components/games/games_tab.cpp
+++ b/components/games/games_tab.cpp
@@ -12,6 +12,8 @@
 #include "../components.h"
 #include "../../utils/launcher.hpp"
 #include "../../utils/roblox_api.h"
+#include "../../utils/status.h"
+#include "../../utils/modal_popup.h"
 #include "../../ui.h"
 
 using namespace ImGui;
@@ -337,6 +339,7 @@ static void RenderGameDetailsPanel(float panelWidth, float availableHeight) {
                 }
             } else {
                 Status::Set("No account selected to launch game.");
+                ModalPopup::Add("Select an account first.");
             }
         }
         SameLine();

--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -18,6 +18,8 @@
 
 #include "../../utils/threading.h"
 #include "../../utils/launcher.hpp"
+#include "../../utils/modal_popup.h"
+#include "../../utils/status.h"
 #include "../../ui.h"
 #include "../data.h"
 
@@ -243,6 +245,10 @@ void RenderHistoryTab() {
                     }
                 } else {
                     LOG_INFO("Place ID missing or no account selected.");
+                    if (g_selectedAccountIds.empty())
+                        ModalPopup::Add("Select an account first.");
+                    else
+                        ModalPopup::Add("Invalid log entry.");
                 }
             }
 

--- a/components/servers/servers_tab.cpp
+++ b/components/servers/servers_tab.cpp
@@ -18,6 +18,7 @@
 #include "../../utils/roblox_api.h"
 #include "../../utils/status.h"
 #include "../../utils/launcher.hpp"
+#include "../../utils/modal_popup.h"
 #include "../../ui.h"
 
 using namespace ImGui;
@@ -204,6 +205,7 @@ void RenderServersTab() {
                     }
                 } else {
                     LOG_INFO("No account selected to join server.");
+                    ModalPopup::Add("Select an account first.");
                 }
             }
 
@@ -233,6 +235,7 @@ void RenderServersTab() {
                         }
                     } else {
                         LOG_INFO("No account selected to join server.");
+                        ModalPopup::Add("Select an account first.");
                     }
                 }
                 EndPopup();

--- a/ui.cpp
+++ b/ui.cpp
@@ -11,6 +11,7 @@
 #include "settings/settings.h"
 #include "utils/roblox_api.h"
 #include "utils/status.h"
+#include "utils/modal_popup.h"
 
 using namespace ImGui;
 
@@ -91,6 +92,8 @@ bool RenderUI() {
     }
 
     End();
+
+    ModalPopup::Render();
 
     return exit_from_menu || exit_from_content;
 }

--- a/utils/modal_popup.h
+++ b/utils/modal_popup.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <imgui.h>
+#include <deque>
+#include <string>
+
+namespace ModalPopup {
+    struct Notification {
+        std::string message;
+        bool open = true;
+    };
+
+    inline std::deque<Notification> queue;
+
+    inline void Add(const std::string &msg) {
+        queue.push_back({msg, true});
+    }
+
+    inline void Render() {
+        if (queue.empty()) return;
+        Notification &current = queue.front();
+        if (current.open) {
+            ImGui::OpenPopup("Notification");
+            current.open = false;
+        }
+        if (ImGui::BeginPopupModal("Notification", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+            ImGui::TextWrapped("%s", current.message.c_str());
+            ImGui::Spacing();
+            if (ImGui::Button("OK", ImVec2(120, 0))) {
+                ImGui::CloseCurrentPopup();
+                queue.pop_front();
+            }
+            ImGui::EndPopup();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `ModalPopup` utility
- show popups when no account is selected for join actions
- hook modal rendering into UI

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "cpr"...)*

------
https://chatgpt.com/codex/tasks/task_b_6840df88d4188320a68af8189f8f073a