### PR TITLE
Improve history list grouping

### DIFF
--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -199,13 +199,39 @@ void RenderHistoryTab() {
 
     BeginChild("##HistoryList", ImVec2(listWidth, 0), true); {
         lock_guard<mutex> lk(g_logs_mtx);
+        string lastDay;
+        string lastVersion;
+        bool indented = false;
+
         for (int i = 0; i < static_cast<int>(g_logs.size()); ++i) {
             const auto &logInfo = g_logs[i];
+
+            string thisDay = logInfo.timestamp.size() >= 10 ? logInfo.timestamp.substr(0, 10) : "Unknown";
+            string thisVersion = logInfo.version.empty() ? "" : logInfo.version;
+
+            if (thisDay != lastDay || thisVersion != lastVersion) {
+                if (indented)
+                    Unindent();
+                string header = thisDay;
+                if (!thisVersion.empty())
+                    header += "  v" + thisVersion;
+                else
+                    header += "  Unknown Version";
+                SeparatorText(header.c_str());
+                Indent();
+                indented = true;
+                lastDay = thisDay;
+                lastVersion = thisVersion;
+            }
+
             PushID(i);
             if (Selectable(niceLabel(logInfo).c_str(), g_selected_log_idx == i))
                 g_selected_log_idx = i;
             PopID();
         }
+
+        if (indented)
+            Unindent();
     }
     EndChild();
     SameLine();

--- a/components/history/history_utils.cpp
+++ b/components/history/history_utils.cpp
@@ -68,10 +68,17 @@ string friendlyTimestamp(const string &isoTimestamp) {
 
 string niceLabel(const LogInfo &logInfo) {
     if (!logInfo.timestamp.empty()) {
-        string date = logInfo.timestamp.substr(0, 10);
-        string time = logInfo.timestamp.substr(11, 5);
-        // Entries are grouped by version, so omit it from the label
-        return time + " " + date;
+        string hourStr = logInfo.timestamp.substr(11, 2);
+        string minute = logInfo.timestamp.substr(14, 2);
+        int hour = stoi(hourStr);
+        int hour12 = hour % 12;
+        if (hour12 == 0)
+            hour12 = 12;
+        string ampm = hour >= 12 ? "PM" : "AM";
+        ostringstream ss;
+        ss << hour12 << ':' << minute << ' ' << ampm;
+        // Entries are grouped by day and version, so omit them from the label
+        return ss.str();
     }
     return logInfo.fileName;
 }

--- a/components/history/history_utils.cpp
+++ b/components/history/history_utils.cpp
@@ -67,10 +67,11 @@ string friendlyTimestamp(const string &isoTimestamp) {
 }
 
 string niceLabel(const LogInfo &logInfo) {
-    if (!logInfo.timestamp.empty() && !logInfo.version.empty()) {
+    if (!logInfo.timestamp.empty()) {
         string date = logInfo.timestamp.substr(0, 10);
         string time = logInfo.timestamp.substr(11, 5);
-        return time + " " + date + "  v" + logInfo.version;
+        // Entries are grouped by version, so omit it from the label
+        return time + " " + date;
     }
     return logInfo.fileName;
 }


### PR DESCRIPTION
## Summary
- group history sidebar logs by day and client version

## Testing
- `cmake -S . -B build` *(fails: could not find `cpr` package)*

------
https://chatgpt.com/codex/tasks/task_b_684111c610e48320a8a6aa4cd297ab72