### PR TITLE
Add long press to open account browser

### DIFF
--- a/components/accounts/accounts_context_menu.h
+++ b/components/accounts/accounts_context_menu.h
@@ -4,3 +4,5 @@
 #include "../data.h"
 
 void RenderAccountContextMenu(AccountData& account, const std::string& unique_context_menu_id);
+
+void LaunchBrowserWithCookie(const AccountData &account);

--- a/components/accounts/accounts_tab.cpp
+++ b/components/accounts/accounts_tab.cpp
@@ -7,12 +7,16 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <unordered_map>
 
 #include "../../utils/roblox_api.h"
 #include "../components.h"
 #include "../../utils/time_utils.h"
+#include "../../utils/logging.hpp"
+#include "../../utils/status.h"
 #include "../../ui.h"
 #include "../data.h"
+#include "../../utils/threading.h"
 
 using namespace ImGui;
 
@@ -88,6 +92,26 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
                     g_selectedAccountIds.clear();
                     if (!was_already_solely_selected) g_selectedAccountIds.insert(account.id);
                 }
+            }
+
+            static std::unordered_map<int, double> holdStartTimes;
+            if (IsItemActivated() && IsMouseDown(ImGuiMouseButton_Left)) {
+                holdStartTimes[account.id] = ImGui::GetTime();
+            }
+            if (IsItemActive()) {
+                auto it = holdStartTimes.find(account.id);
+                if (it != holdStartTimes.end() && (ImGui::GetTime() - it->second) >= 1.5f) {
+                    holdStartTimes.erase(it);
+                    if (!account.cookie.empty()) {
+                        LOG_INFO("Opening browser for account: " + account.displayName + " (ID: " + std::to_string(account.id) + ")");
+                        Threading::newThread([acc = account]() { LaunchBrowserWithCookie(acc); });
+                    } else {
+                        LOG_WARN("Cannot open browser - cookie is empty for account: " + account.displayName);
+                        Status::Error("Cookie is empty for this account");
+                    }
+                }
+            } else {
+                holdStartTimes.erase(account.id);
             }
 
             string context_menu_id = string(table_id) + "_ContextMenu_" + to_string(account.id);


### PR DESCRIPTION
## Summary
- declare `LaunchBrowserWithCookie` in header
- on Accounts table rows, detect long press and launch browser
- include additional headers for threading, logging, and status

## Testing
- `cmake -S . -B build` *(fails: Could not find `cpr`)*

------
https://chatgpt.com/codex/tasks/task_b_6843771558fc8320b2dbf1a3c3f514d7