### PR TITLE
Fix history tab timezone display

### DIFF
--- a/components/history/history_utils.h
+++ b/components/history/history_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <ctime>
 #include "log_types.h"
 
 std::string ordSuffix(int day);
@@ -8,3 +9,6 @@ std::string ordSuffix(int day);
 std::string friendlyTimestamp(const std::string& isoTimestamp);
 
 std::string niceLabel(const LogInfo& logInfo);
+
+// Convert an ISO8601 UTC timestamp to local time. Returns true on success.
+bool isoTimestampToLocalTm(const std::string& isoTimestamp, std::tm& outTm);


### PR DESCRIPTION
## Summary
- convert ISO timestamps to local time when rendering history labels
- expose helper to convert an ISO UTC timestamp to local `tm`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_b_684379c305fc8320b728d7b646b2f319