### PR TITLE
Track account friends and detect unfriending

### DIFF
--- a/components/data.h
+++ b/components/data.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <array>
 #include <ctime>
+#include <unordered_map>
 #include <imgui.h>
 
 struct AccountData {
@@ -41,6 +42,8 @@ struct FriendInfo {
 extern std::vector<FavoriteGame> g_favorites;
 extern std::vector<AccountData> g_accounts;
 extern std::vector<FriendInfo> g_friends;
+extern std::unordered_map<int, std::vector<FriendInfo>> g_accountFriends;
+extern std::unordered_map<int, std::vector<FriendInfo>> g_unfriendedFriends;
 extern std::set<int> g_selectedAccountIds;
 extern ImVec4 g_accentColor;
 

--- a/components/friends/friends_actions.cpp
+++ b/components/friends/friends_actions.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <unordered_set>
 
 using namespace std;
 
@@ -19,6 +20,7 @@ static int presencePriority(const string &p) {
 
 namespace FriendsActions {
     void RefreshFullFriendsList(
+        int accountId,
         const string &userId,
         const string &cookie,
         vector<FriendInfo> &outFriendsList,
@@ -95,6 +97,23 @@ namespace FriendsActions {
              });
 
         outFriendsList = move(list);
+
+        vector<FriendInfo> unfriended;
+        {
+            unordered_set<uint64_t> newIds;
+            for (const auto &f : outFriendsList)
+                newIds.insert(f.id);
+            auto itOld = g_accountFriends.find(accountId);
+            if (itOld != g_accountFriends.end()) {
+                for (const auto &oldF : itOld->second) {
+                    if (!newIds.contains(oldF.id))
+                        unfriended.push_back(oldF);
+                }
+            }
+            g_accountFriends[accountId] = outFriendsList;
+        }
+        g_unfriendedFriends[accountId] = std::move(unfriended);
+        Data::SaveFriends();
         loadingFlag = false;
         LOG_INFO("Friends list updated.");
     }

--- a/components/friends/friends_actions.h
+++ b/components/friends/friends_actions.h
@@ -9,11 +9,12 @@
 
 namespace FriendsActions
 {
-	void RefreshFullFriendsList(
-		const std::string& userId,
-		const std::string& cookie,
-		std::vector<FriendInfo>& outFriendsList,
-		std::atomic<bool>& loadingFlag);
+        void RefreshFullFriendsList(
+                int accountId,
+                const std::string& userId,
+                const std::string& cookie,
+                std::vector<FriendInfo>& outFriendsList,
+                std::atomic<bool>& loadingFlag);
 
 	void FetchFriendDetails(
 		const std::string& friendId,

--- a/main.cpp
+++ b/main.cpp
@@ -120,6 +120,7 @@ int WINAPI WinMain(
 
     Data::LoadSettings("settings.json");
     Data::LoadAccounts("accounts.json");
+    Data::LoadFriends("friends.json");
 
     for (auto &acct: g_accounts) {
         if (!acct.userId.empty()) {


### PR DESCRIPTION
## Summary
- store friends for each account
- load/save `friends.json`
- update friends refresh logic to record removed friends
- show unfriended accounts at bottom of friends list
- support removing from stored friends when unfriending via context menu
- load saved friends during startup

## Testing
- `cmake -B build` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_b_68437defccbc8320944de6bff7e31305