### PR TITLE
Persist unfriended friends list

### DIFF
--- a/components/data.h
+++ b/components/data.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <array>
 #include <ctime>
+#include <unordered_map>
 #include <imgui.h>
 
 struct AccountData {
@@ -41,6 +42,8 @@ struct FriendInfo {
 extern std::vector<FavoriteGame> g_favorites;
 extern std::vector<AccountData> g_accounts;
 extern std::vector<FriendInfo> g_friends;
+extern std::unordered_map<int, std::vector<FriendInfo>> g_accountFriends;
+extern std::unordered_map<int, std::vector<FriendInfo>> g_unfriendedFriends;
 extern std::set<int> g_selectedAccountIds;
 extern ImVec4 g_accentColor;
 

--- a/components/friends/friends_actions.h
+++ b/components/friends/friends_actions.h
@@ -9,11 +9,12 @@
 
 namespace FriendsActions
 {
-	void RefreshFullFriendsList(
-		const std::string& userId,
-		const std::string& cookie,
-		std::vector<FriendInfo>& outFriendsList,
-		std::atomic<bool>& loadingFlag);
+        void RefreshFullFriendsList(
+                int accountId,
+                const std::string& userId,
+                const std::string& cookie,
+                std::vector<FriendInfo>& outFriendsList,
+                std::atomic<bool>& loadingFlag);
 
 	void FetchFriendDetails(
 		const std::string& friendId,

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -23,6 +23,7 @@ static int g_selectedFriendIdx = -1;
 static RobloxApi::FriendDetail g_selectedFriend;
 static atomic<bool> g_friendDetailsLoading{false};
 static atomic<bool> g_friendsLoading{false};
+static vector<FriendInfo> g_unfriended;
 
 static int g_lastAcctIdForFriends = -1;
 
@@ -72,6 +73,7 @@ void RenderFriendsTab() {
         return;
     }
     const AccountData &acct = *it;
+    g_unfriended = g_unfriendedFriends[currentAcctId];
 
     if (currentAcctId != g_lastAcctIdForFriends) {
         g_friends.clear();
@@ -79,10 +81,11 @@ void RenderFriendsTab() {
         g_selectedFriend = {};
         g_friendsLoading = false;
         g_friendDetailsLoading = false;
+        g_unfriended = g_unfriendedFriends[currentAcctId];
         g_lastAcctIdForFriends = currentAcctId;
 
         if (!acct.userId.empty()) {
-            Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.userId, acct.cookie, ref(g_friends),
+            Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie, ref(g_friends),
                                  ref(g_friendsLoading));
         }
     }
@@ -91,7 +94,7 @@ void RenderFriendsTab() {
     if (Button((string(ICON_REFRESH) + "Refresh").c_str()) && !acct.userId.empty()) {
         g_selectedFriendIdx = -1;
         g_selectedFriend = {};
-        Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.userId, acct.cookie, ref(g_friends),
+        Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie, ref(g_friends),
                              ref(g_friendsLoading));
     }
     SameLine();
@@ -192,9 +195,11 @@ void RenderFriendsTab() {
 
             if (BeginPopupContextItem("FriendRowContextMenu")) {
                 if (MenuItem("Unfriend")) {
-                    uint64_t friendId = f.id;
+                    FriendInfo fCopy = f;
+                    uint64_t friendId = fCopy.id;
                     string cookieCopy = acct.cookie;
-                    Threading::newThread([friendId, cookieCopy]() {
+                    int acctIdCopy = acct.id;
+                    Threading::newThread([fCopy, friendId, cookieCopy, acctIdCopy]() {
                         string resp;
                         bool ok = RobloxApi::unfriend(to_string(friendId), cookieCopy, &resp);
                         if (ok) {
@@ -203,6 +208,11 @@ void RenderFriendsTab() {
                                 g_selectedFriendIdx = -1;
                                 g_selectedFriend = {};
                             }
+                            erase_if(g_accountFriends[acctIdCopy], [&](const FriendInfo &fi) { return fi.id == friendId; });
+                            auto &unfList = g_unfriendedFriends[acctIdCopy];
+                            if (std::none_of(unfList.begin(), unfList.end(), [&](const FriendInfo &fi){ return fi.id == friendId; }))
+                                unfList.push_back(fCopy);
+                            Data::SaveFriends();
                         } else {
                             cerr << "Unfriend failed: " << resp << "\n";
                         }
@@ -223,6 +233,18 @@ void RenderFriendsTab() {
                 }
             }
             PopID();
+        }
+
+        if (!g_unfriended.empty()) {
+            Separator();
+            PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+            TextUnformatted("Unfriended:");
+            for (const auto &uf : g_unfriended) {
+                string name = uf.displayName.empty() || uf.displayName == uf.username ?
+                               uf.username : uf.displayName + " (" + uf.username + ")";
+                TextUnformatted(name.c_str());
+            }
+            PopStyleColor();
         }
     }
     EndChild();

--- a/main.cpp
+++ b/main.cpp
@@ -120,6 +120,7 @@ int WINAPI WinMain(
 
     Data::LoadSettings("settings.json");
     Data::LoadAccounts("accounts.json");
+    Data::LoadFriends("friends.json");
 
     for (auto &acct: g_accounts) {
         if (!acct.userId.empty()) {


### PR DESCRIPTION
## Summary
- persist per-account unfriended friends in `friends.json`
- merge newly removed friends with stored list on refresh
- add removed friends to unfriended list when unfriending via context menu

## Testing
- `cmake -B build` *(fails: Could not find a package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_b_68437defccbc8320944de6bff7e31305