### PR TITLE
Add invite copy options and browser submenu

### DIFF
--- a/components/accounts/accounts_context_menu.cpp
+++ b/components/accounts/accounts_context_menu.cpp
@@ -140,16 +140,19 @@ void RenderAccountContextMenu(AccountData &account, const string &unique_context
                     SetClipboardText(jobId.c_str());
                 if (BeginMenu("Copy Launch Method")) {
                     char buf[256];
-                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)placeId, jobId.c_str());
+                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long) placeId,
+                             jobId.c_str());
                     if (MenuItem("Deep Link")) SetClipboardText(buf);
                     string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(placeId) + ", \"" + jobId + "\")";
                     if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
-                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(placeId) + ", \"" + jobId + "\")";
+                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(placeId) +
+                                  ", \"" + jobId + "\")";
                     if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
-                    EndMenu();
+                    ImGui::EndMenu();
                 }
                 if (MenuItem("Generate Invite Link")) {
-                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(placeId) + "&gameInstanceId=" + jobId;
+                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(placeId) +
+                                  "&gameInstanceId=" + jobId;
                     SetClipboardText(link.c_str());
                 }
                 Separator();
@@ -161,11 +164,13 @@ void RenderAccountContextMenu(AccountData &account, const string &unique_context
         if (BeginMenu("Open In Browser")) {
             if (MenuItem("Home Page")) {
                 if (!account.cookie.empty())
-                    LaunchWebview("https://www.roblox.com/home", account.username + " - " + account.userId, account.cookie);
+                    LaunchWebview("https://www.roblox.com/home", account.username + " - " + account.userId,
+                                  account.cookie);
             }
             if (MenuItem("Profile")) {
                 if (!account.cookie.empty())
-                    LaunchWebview("https://www.roblox.com/users/" + account.userId + "/profile", account.username, account.cookie);
+                    LaunchWebview("https://www.roblox.com/users/" + account.userId + "/profile", account.username,
+                                  account.cookie);
             }
             if (MenuItem("Avatar")) {
                 if (!account.cookie.empty())
@@ -192,7 +197,7 @@ void RenderAccountContextMenu(AccountData &account, const string &unique_context
                 g_customUrlAccountId = account.id;
                 g_customUrlBuffer[0] = '\0';
             }
-            EndMenu();
+            ImGui::EndMenu();
         }
 
         if (MenuItem("Copy Launch Link")) {

--- a/components/accounts/accounts_context_menu.cpp
+++ b/components/accounts/accounts_context_menu.cpp
@@ -31,6 +31,10 @@ using Microsoft::WRL::ComPtr;
 static char g_edit_note_buffer_ctx[1024];
 static int g_editing_note_for_account_id_ctx = -1;
 
+static bool g_openCustomUrlPopup = false;
+static int g_customUrlAccountId = -1;
+static char g_customUrlBuffer[256] = "";
+
 using namespace ImGui;
 using namespace std;
 
@@ -116,19 +120,79 @@ void RenderAccountContextMenu(AccountData &account, const string &unique_context
             LOG_INFO("Copied Note for account: " + account.displayName);
         }
 
+        if (account.status == "InGame") {
+            uint64_t placeId = 0;
+            string jobId;
+            try {
+                auto pres = RobloxApi::getPresences({stoull(account.userId)}, account.cookie);
+                auto itp = pres.find(stoull(account.userId));
+                if (itp != pres.end()) {
+                    placeId = itp->second.placeId;
+                    jobId = itp->second.gameId;
+                }
+            } catch (...) {
+            }
+
+            if (placeId && !jobId.empty()) {
+                if (MenuItem("Copy Place ID"))
+                    SetClipboardText(to_string(placeId).c_str());
+                if (MenuItem("Copy Job ID"))
+                    SetClipboardText(jobId.c_str());
+                if (BeginMenu("Copy Launch Method")) {
+                    char buf[256];
+                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)placeId, jobId.c_str());
+                    if (MenuItem("Deep Link")) SetClipboardText(buf);
+                    string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(placeId) + ", \"" + jobId + "\")";
+                    if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
+                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(placeId) + ", \"" + jobId + "\")";
+                    if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
+                    EndMenu();
+                }
+                if (MenuItem("Generate Invite Link")) {
+                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(placeId) + "&gameInstanceId=" + jobId;
+                    SetClipboardText(link.c_str());
+                }
+                Separator();
+            }
+        }
+
         Separator();
 
-        if (MenuItem("Open In Browser")) {
-            if (!account.cookie.empty()) {
-                LOG_INFO(
-                    "Opening browser for account: " + account.displayName + " (ID: " + to_string(account.id) + ")");
-                Threading::newThread([account]() {
-                    LaunchBrowserWithCookie(account);
-                });
-            } else {
-                LOG_WARN("Cannot open browser - cookie is empty for account: " + account.displayName);
-                Status::Error("Cookie is empty for this account");
+        if (BeginMenu("Open In Browser")) {
+            if (MenuItem("Home Page")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/home", account.username + " - " + account.userId, account.cookie);
             }
+            if (MenuItem("Profile")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/users/" + account.userId + "/profile", account.username, account.cookie);
+            }
+            if (MenuItem("Avatar")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/my/avatar", account.username, account.cookie);
+            }
+            if (MenuItem("Friends")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/users/friends", account.username, account.cookie);
+            }
+            if (MenuItem("Messages")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/my/messages", account.username, account.cookie);
+            }
+            if (MenuItem("Catalog")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://www.roblox.com/catalog", account.username, account.cookie);
+            }
+            if (MenuItem("Creator Hub")) {
+                if (!account.cookie.empty())
+                    LaunchWebview("https://create.roblox.com/", account.username, account.cookie);
+            }
+            if (MenuItem("Custom URL")) {
+                g_openCustomUrlPopup = true;
+                g_customUrlAccountId = account.id;
+                g_customUrlBuffer[0] = '\0';
+            }
+            EndMenu();
         }
 
         if (MenuItem("Copy Launch Link")) {
@@ -222,6 +286,28 @@ void RenderAccountContextMenu(AccountData &account, const string &unique_context
                 });
             }
             PopStyleColor();
+        }
+        EndPopup();
+    }
+
+    if (g_openCustomUrlPopup && g_customUrlAccountId == account.id) {
+        string popupId = "Custom URL##Acct" + to_string(account.id);
+        OpenPopup(popupId.c_str());
+        g_openCustomUrlPopup = false;
+    }
+    string popupName = "Custom URL##Acct" + to_string(account.id);
+    if (BeginPopupModal(popupName.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        InputTextWithHint("##AcctUrl", "Enter URL", g_customUrlBuffer, sizeof(g_customUrlBuffer));
+        Spacing();
+        if (Button("Open") && g_customUrlBuffer[0] != '\0') {
+            LaunchWebview(g_customUrlBuffer, account.username + " - " + account.userId, account.cookie);
+            g_customUrlBuffer[0] = '\0';
+            CloseCurrentPopup();
+        }
+        SameLine();
+        if (Button("Cancel")) {
+            g_customUrlBuffer[0] = '\0';
+            CloseCurrentPopup();
         }
         EndPopup();
     }

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -42,449 +42,449 @@ static char s_addFriendBuffer[64] = "";
 static atomic<bool> s_addFriendLoading{false};
 
 static inline string trim_copy(string s) {
-    size_t start = s.find_first_not_of(" \t\n\r");
-    size_t end = s.find_last_not_of(" \t\n\r");
-    if (start == string::npos) return "";
-    return s.substr(start, end - start + 1);
+	size_t start = s.find_first_not_of(" \t\n\r");
+	size_t end = s.find_last_not_of(" \t\n\r");
+	if (start == string::npos) return "";
+	return s.substr(start, end - start + 1);
 }
 
 static const char *presenceIcon(const string &p) {
-    if (p == "InStudio")
-        return ICON_TOOL;
-    if (p == "InGame")
-        return ICON_CONTROLLER;
-    if (p == "Online")
-        return ICON_PERSON;
-    return "";
+	if (p == "InStudio")
+		return ICON_TOOL;
+	if (p == "InGame")
+		return ICON_CONTROLLER;
+	if (p == "Online")
+		return ICON_PERSON;
+	return "";
 }
 
 
 void RenderFriendsTab() {
-    if (g_selectedAccountIds.empty()) {
-        TextDisabled("Select an account in the Accounts tab to view its friends.");
-        return;
-    }
-    int currentAcctId = *g_selectedAccountIds.begin();
-    auto it = find_if(g_accounts.begin(), g_accounts.end(),
-                      [&](auto &a) {
-                          return a.id == currentAcctId;
-                      });
-    if (it == g_accounts.end()) {
-        TextDisabled("Selected account not found.");
-        return;
-    }
-    const AccountData &acct = *it;
-    g_unfriended = g_unfriendedFriends[currentAcctId];
+	if (g_selectedAccountIds.empty()) {
+		TextDisabled("Select an account in the Accounts tab to view its friends.");
+		return;
+	}
+	int currentAcctId = *g_selectedAccountIds.begin();
+	auto it = find_if(g_accounts.begin(), g_accounts.end(),
+	                  [&](auto &a) {
+		                  return a.id == currentAcctId;
+	                  });
+	if (it == g_accounts.end()) {
+		TextDisabled("Selected account not found.");
+		return;
+	}
+	const AccountData &acct = *it;
+	g_unfriended = g_unfriendedFriends[currentAcctId];
 
-    if (currentAcctId != g_lastAcctIdForFriends) {
-        g_friends.clear();
-        g_selectedFriendIdx = -1;
-        g_selectedFriend = {};
-        g_friendsLoading = false;
-        g_friendDetailsLoading = false;
-        g_unfriended = g_unfriendedFriends[currentAcctId];
-        g_lastAcctIdForFriends = currentAcctId;
+	if (currentAcctId != g_lastAcctIdForFriends) {
+		g_friends.clear();
+		g_selectedFriendIdx = -1;
+		g_selectedFriend = {};
+		g_friendsLoading = false;
+		g_friendDetailsLoading = false;
+		g_unfriended = g_unfriendedFriends[currentAcctId];
+		g_lastAcctIdForFriends = currentAcctId;
 
-        if (!acct.userId.empty()) {
-            Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie,
-                                 ref(g_friends),
-                                 ref(g_friendsLoading));
-        }
-    }
+		if (!acct.userId.empty()) {
+			Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie,
+			                     ref(g_friends),
+			                     ref(g_friendsLoading));
+		}
+	}
 
-    BeginDisabled(g_friendsLoading.load());
-    if (Button((string(ICON_REFRESH) + "Refresh").c_str()) && !acct.userId.empty()) {
-        g_selectedFriendIdx = -1;
-        g_selectedFriend = {};
-        Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie, ref(g_friends),
-                             ref(g_friendsLoading));
-    }
-    SameLine();
-    if (Button((string(ICON_USER_PLUS) + "Add Friend").c_str())) {
-        s_openAddFriendPopup = true;
-    }
-    EndDisabled();
+	BeginDisabled(g_friendsLoading.load());
+	if (Button((string(ICON_REFRESH) + "Refresh").c_str()) && !acct.userId.empty()) {
+		g_selectedFriendIdx = -1;
+		g_selectedFriend = {};
+		Threading::newThread(FriendsActions::RefreshFullFriendsList, acct.id, acct.userId, acct.cookie, ref(g_friends),
+		                     ref(g_friendsLoading));
+	}
+	SameLine();
+	if (Button((string(ICON_USER_PLUS) + "Add Friend").c_str())) {
+		s_openAddFriendPopup = true;
+	}
+	EndDisabled();
 
-    if (s_openAddFriendPopup) {
-        OpenPopup("Add Friend");
-        s_openAddFriendPopup = false;
-    }
-    if (BeginPopupModal("Add Friend", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
-        InputTextWithHint("##AddFriendUser", "Username or ID", s_addFriendBuffer, sizeof(s_addFriendBuffer));
-        if (s_addFriendLoading.load()) {
-            SameLine();
-            TextUnformatted("Sending...");
-        }
-        Spacing();
-        if (Button("Send") && s_addFriendBuffer[0] != '\0' && !s_addFriendLoading.load()) {
-            string input = trim_copy(s_addFriendBuffer);
-            s_addFriendLoading = true;
-            Threading::newThread([input, cookie = acct.cookie]() {
-                try {
-                    uint64_t uid = 0;
-                    if (input.empty()) throw runtime_error("Username not provided");
-                    if (all_of(input.begin(), input.end(), [](unsigned char c) { return std::isdigit(c); })) {
-                        uid = stoull(input);
-                    } else {
-                        uid = RobloxApi::getUserIdFromUsername(input);
-                    }
-                    string resp;
-                    bool ok = RobloxApi::sendFriendRequest(to_string(uid), cookie, &resp);
-                    if (ok) {
-                        LOG_INFO("Friend request sent");
-                        cerr << "Friend request response: " << resp << "\n";
-                    } else {
-                        cerr << "Friend request failed: " << resp << "\n";
-                        LOG_INFO("Friend request failed");
-                    }
-                } catch (const exception &e) {
-                    cerr << "Friend request exception: " << e.what() << "\n";
-                    LOG_INFO(e.what());
-                }
-                s_addFriendLoading = false;
-            });
-            s_addFriendBuffer[0] = '\0';
-            CloseCurrentPopup();
-        }
-        SameLine();
-        if (Button("Cancel") && !s_addFriendLoading.load()) {
-            s_addFriendBuffer[0] = '\0';
-            CloseCurrentPopup();
-        }
-        EndPopup();
-    }
+	if (s_openAddFriendPopup) {
+		OpenPopup("Add Friend");
+		s_openAddFriendPopup = false;
+	}
+	if (BeginPopupModal("Add Friend", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+		InputTextWithHint("##AddFriendUser", "Username or ID", s_addFriendBuffer, sizeof(s_addFriendBuffer));
+		if (s_addFriendLoading.load()) {
+			SameLine();
+			TextUnformatted("Sending...");
+		}
+		Spacing();
+		if (Button("Send") && s_addFriendBuffer[0] != '\0' && !s_addFriendLoading.load()) {
+			string input = trim_copy(s_addFriendBuffer);
+			s_addFriendLoading = true;
+			Threading::newThread([input, cookie = acct.cookie]() {
+				try {
+					uint64_t uid = 0;
+					if (input.empty()) throw runtime_error("Username not provided");
+					if (all_of(input.begin(), input.end(), [](unsigned char c) { return std::isdigit(c); })) {
+						uid = stoull(input);
+					} else {
+						uid = RobloxApi::getUserIdFromUsername(input);
+					}
+					string resp;
+					bool ok = RobloxApi::sendFriendRequest(to_string(uid), cookie, &resp);
+					if (ok) {
+						LOG_INFO("Friend request sent");
+						cerr << "Friend request response: " << resp << "\n";
+					} else {
+						cerr << "Friend request failed: " << resp << "\n";
+						LOG_INFO("Friend request failed");
+					}
+				} catch (const exception &e) {
+					cerr << "Friend request exception: " << e.what() << "\n";
+					LOG_INFO(e.what());
+				}
+				s_addFriendLoading = false;
+			});
+			s_addFriendBuffer[0] = '\0';
+			CloseCurrentPopup();
+		}
+		SameLine();
+		if (Button("Cancel") && !s_addFriendLoading.load()) {
+			s_addFriendBuffer[0] = '\0';
+			CloseCurrentPopup();
+		}
+		EndPopup();
+	}
 
-    float friendsListWidth = 300.0f;
+	float friendsListWidth = 300.0f;
 
-    BeginChild("##FriendsList", ImVec2(friendsListWidth, 0), true);
-    if (g_friendsLoading.load() && g_friends.empty()) {
-        Text("Loading friends...");
-    } else {
-        for (size_t i = 0; i < g_friends.size(); ++i) {
-            const auto &f = g_friends[i];
-            PushID(static_cast<int>(i));
+	BeginChild("##FriendsList", ImVec2(friendsListWidth, 0), true);
+	if (g_friendsLoading.load() && g_friends.empty()) {
+		Text("Loading friends...");
+	} else {
+		for (size_t i = 0; i < g_friends.size(); ++i) {
+			const auto &f = g_friends[i];
+			PushID(static_cast<int>(i));
 
-            string label;
-            const char *icon = presenceIcon(f.presence);
-            if (*icon) label += icon;
-            label += (f.displayName == f.username || f.displayName.empty())
-                         ? f.username
-                         : (f.displayName + " (" + f.username + ")");
+			string label;
+			const char *icon = presenceIcon(f.presence);
+			if (*icon) label += icon;
+			label += (f.displayName == f.username || f.displayName.empty())
+				         ? f.username
+				         : (f.displayName + " (" + f.username + ")");
 
-            ImVec4 txtCol = getStatusColor(f.presence);
-            PushStyleColor(ImGuiCol_Text, txtCol);
+			ImVec4 txtCol = getStatusColor(f.presence);
+			PushStyleColor(ImGuiCol_Text, txtCol);
 
-            bool clicked = Selectable(label.c_str(),
-                                      g_selectedFriendIdx == static_cast<int>(i),
-                                      ImGuiSelectableFlags_SpanAllColumns);
+			bool clicked = Selectable(label.c_str(),
+			                          g_selectedFriendIdx == static_cast<int>(i),
+			                          ImGuiSelectableFlags_SpanAllColumns);
 
-            PopStyleColor();
-            if (f.presence == "InGame" && !f.lastLocation.empty()) {
-                const float indent = GetStyle().FramePadding.x * 4.0f;
-                Indent(indent);
-                ImVec4 gameCol = txtCol;
-                gameCol.x *= 0.75f;
-                gameCol.y *= 0.75f;
-                gameCol.z *= 0.75f;
-                gameCol.w *= 0.65f;
+			PopStyleColor();
+			if (f.presence == "InGame" && !f.lastLocation.empty()) {
+				const float indent = GetStyle().FramePadding.x * 4.0f;
+				Indent(indent);
+				ImVec4 gameCol = txtCol;
+				gameCol.x *= 0.75f;
+				gameCol.y *= 0.75f;
+				gameCol.z *= 0.75f;
+				gameCol.w *= 0.65f;
 
-                PushStyleColor(ImGuiCol_Text, gameCol);
-                TextUnformatted(string("\xEF\x83\x9A  " + f.lastLocation).c_str());
-                PopStyleColor();
+				PushStyleColor(ImGuiCol_Text, gameCol);
+				TextUnformatted(string("\xEF\x83\x9A  " + f.lastLocation).c_str());
+				PopStyleColor();
 
-                Unindent(indent);
-            }
+				Unindent(indent);
+			}
 
-            if (BeginPopupContextItem("FriendRowContextMenu")) {
-                if (MenuItem("Copy Display Name")) {
-                    SetClipboardText(f.displayName.c_str());
-                }
-                if (MenuItem("Copy Username")) {
-                    SetClipboardText(f.username.c_str());
-                }
-                if (MenuItem("Copy User ID")) {
-                    string idStr = to_string(f.id);
-                    SetClipboardText(idStr.c_str());
-                }
-                Separator();
-                if (f.presence == "InGame" && f.placeId && !f.gameId.empty()) {
-                    if (MenuItem("Join")) {
-                        vector<pair<int, string> > accounts;
-                        for (int id: g_selectedAccountIds) {
-                            auto itA = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) {
-                                return a.id == id;
-                            });
-                            if (itA != g_accounts.end())
-                                accounts.emplace_back(itA->id, itA->cookie);
-                        }
-                        if (!accounts.empty()) {
-                            Threading::newThread([row = f, accounts]() {
-                                launchRobloxSequential(row.placeId, row.gameId, accounts);
-                            });
-                        }
-                    }
-                    if (MenuItem("Copy Place ID")) {
-                        SetClipboardText(to_string(f.placeId).c_str());
-                    }
-                    if (MenuItem("Copy Job ID")) {
-                        SetClipboardText(f.gameId.c_str());
-                    }
-                    if (BeginMenu("Copy Launch Method")) {
-                        char buf[256];
-                        snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s",
-                                 (unsigned long long) f.placeId, f.gameId.c_str());
-                        if (MenuItem("Deep Link")) SetClipboardText(buf);
-                        string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(f.placeId) + ", \"" + f.gameId +
-                                    "\")";
-                        if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
-                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" +
-                                      to_string(f.placeId) + ", \"" + f.gameId + "\")";
-                        if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
-                        ImGui::EndMenu();
-                    }
-                    if (MenuItem("Generate Invite Link")) {
-                        string link = "https://www.roblox.com/games/start?placeId=" + to_string(f.placeId) +
-                                      "&gameInstanceId=" + f.gameId;
-                        SetClipboardText(link.c_str());
-                    }
-                }
-                Separator();
-                PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
-                if (MenuItem("Unfriend")) {
-                    char buf[256];
-                    snprintf(buf, sizeof(buf), "Unfriend %s?", f.username.c_str());
-                    FriendInfo fCopy = f;
-                    uint64_t friendId = fCopy.id;
-                    string cookieCopy = acct.cookie;
-                    int acctIdCopy = acct.id;
-                    ConfirmPopup::Add(buf, [fCopy, friendId, cookieCopy, acctIdCopy]() {
-                        Threading::newThread([fCopy, friendId, cookieCopy, acctIdCopy]() {
-                            string resp;
-                            bool ok = RobloxApi::unfriend(to_string(friendId), cookieCopy, &resp);
-                            if (ok) {
-                                erase_if(g_friends, [&](const FriendInfo &fi) { return fi.id == friendId; });
-                                if (g_selectedFriendIdx >= 0 && g_selectedFriendIdx < static_cast<int>(g_friends.size())
-                                    &&
-                                    g_friends[g_selectedFriendIdx].id == friendId) {
-                                    g_selectedFriendIdx = -1;
-                                    g_selectedFriend = {};
-                                }
-                                erase_if(g_accountFriends[acctIdCopy], [&](const FriendInfo &fi) {
-                                    return fi.id == friendId;
-                                });
-                                auto &unfList = g_unfriendedFriends[acctIdCopy];
-                                if (std::none_of(unfList.begin(), unfList.end(), [&](const FriendInfo &fi) {
-                                    return fi.id == friendId;
-                                }))
-                                    unfList.push_back(fCopy);
-                                Data::SaveFriends();
-                            } else {
-                                cerr << "Unfriend failed: " << resp << "\n";
-                            }
-                        });
-                    });
-                }
-                PopStyleColor();
-                EndPopup();
-            }
+			if (BeginPopupContextItem("FriendRowContextMenu")) {
+				if (MenuItem("Copy Display Name")) {
+					SetClipboardText(f.displayName.c_str());
+				}
+				if (MenuItem("Copy Username")) {
+					SetClipboardText(f.username.c_str());
+				}
+				if (MenuItem("Copy User ID")) {
+					string idStr = to_string(f.id);
+					SetClipboardText(idStr.c_str());
+				}
+				Separator();
+				if (f.presence == "InGame" && f.placeId && !f.gameId.empty()) {
+					if (MenuItem("Join")) {
+						vector<pair<int, string> > accounts;
+						for (int id: g_selectedAccountIds) {
+							auto itA = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) {
+								return a.id == id;
+							});
+							if (itA != g_accounts.end())
+								accounts.emplace_back(itA->id, itA->cookie);
+						}
+						if (!accounts.empty()) {
+							Threading::newThread([row = f, accounts]() {
+								launchRobloxSequential(row.placeId, row.gameId, accounts);
+							});
+						}
+					}
+					if (MenuItem("Copy Place ID")) {
+						SetClipboardText(to_string(f.placeId).c_str());
+					}
+					if (MenuItem("Copy Job ID")) {
+						SetClipboardText(f.gameId.c_str());
+					}
+					if (BeginMenu("Copy Launch Method")) {
+						char buf[256];
+						snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s",
+						         (unsigned long long) f.placeId, f.gameId.c_str());
+						if (MenuItem("Deep Link")) SetClipboardText(buf);
+						string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(f.placeId) + ", \"" + f.gameId +
+						            "\")";
+						if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
+						string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" +
+						              to_string(f.placeId) + ", \"" + f.gameId + "\")";
+						if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
+						ImGui::EndMenu();
+					}
+					if (MenuItem("Generate Invite Link")) {
+						string link = "https://www.roblox.com/games/start?placeId=" + to_string(f.placeId) +
+						              "&gameInstanceId=" + f.gameId;
+						SetClipboardText(link.c_str());
+					}
+				}
+				Separator();
+				PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+				if (MenuItem("Unfriend")) {
+					char buf[256];
+					snprintf(buf, sizeof(buf), "Unfriend %s?", f.username.c_str());
+					FriendInfo fCopy = f;
+					uint64_t friendId = fCopy.id;
+					string cookieCopy = acct.cookie;
+					int acctIdCopy = acct.id;
+					ConfirmPopup::Add(buf, [fCopy, friendId, cookieCopy, acctIdCopy]() {
+						Threading::newThread([fCopy, friendId, cookieCopy, acctIdCopy]() {
+							string resp;
+							bool ok = RobloxApi::unfriend(to_string(friendId), cookieCopy, &resp);
+							if (ok) {
+								erase_if(g_friends, [&](const FriendInfo &fi) { return fi.id == friendId; });
+								if (g_selectedFriendIdx >= 0 && g_selectedFriendIdx < static_cast<int>(g_friends.size())
+								    &&
+								    g_friends[g_selectedFriendIdx].id == friendId) {
+									g_selectedFriendIdx = -1;
+									g_selectedFriend = {};
+								}
+								erase_if(g_accountFriends[acctIdCopy], [&](const FriendInfo &fi) {
+									return fi.id == friendId;
+								});
+								auto &unfList = g_unfriendedFriends[acctIdCopy];
+								if (std::none_of(unfList.begin(), unfList.end(), [&](const FriendInfo &fi) {
+									return fi.id == friendId;
+								}))
+									unfList.push_back(fCopy);
+								Data::SaveFriends();
+							} else {
+								cerr << "Unfriend failed: " << resp << "\n";
+							}
+						});
+					});
+				}
+				PopStyleColor();
+				EndPopup();
+			}
 
-            if (clicked) {
-                g_selectedFriendIdx = static_cast<int>(i);
-                if (g_selectedFriend.id != f.id) {
-                    g_selectedFriend = {};
-                    Threading::newThread(FriendsActions::FetchFriendDetails,
-                                         to_string(f.id),
-                                         acct.cookie,
-                                         ref(g_selectedFriend),
-                                         ref(g_friendDetailsLoading));
-                }
-            }
-            PopID();
-        }
+			if (clicked) {
+				g_selectedFriendIdx = static_cast<int>(i);
+				if (g_selectedFriend.id != f.id) {
+					g_selectedFriend = {};
+					Threading::newThread(FriendsActions::FetchFriendDetails,
+					                     to_string(f.id),
+					                     acct.cookie,
+					                     ref(g_selectedFriend),
+					                     ref(g_friendDetailsLoading));
+				}
+			}
+			PopID();
+		}
 
-        if (!g_unfriended.empty()) {
-            Separator();
-            PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
-            TextUnformatted("Friends Lost:");
-            for (const auto &uf: g_unfriended) {
-                string name = uf.displayName.empty() || uf.displayName == uf.username
-                                  ? uf.username
-                                  : uf.displayName + " (" + uf.username + ")";
-                TextUnformatted(name.c_str());
-            }
-            PopStyleColor();
-        }
-    }
-    EndChild();
+		if (!g_unfriended.empty()) {
+			Separator();
+			PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));
+			TextUnformatted("Friends Lost:");
+			for (const auto &uf: g_unfriended) {
+				string name = uf.displayName.empty() || uf.displayName == uf.username
+					              ? uf.username
+					              : uf.displayName + " (" + uf.username + ")";
+				TextUnformatted(name.c_str());
+			}
+			PopStyleColor();
+		}
+	}
+	EndChild();
 
-    SameLine();
+	SameLine();
 
-    float desiredTextIndent = 8.0f;
-    PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+	float desiredTextIndent = 8.0f;
+	PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
-    BeginChild("##FriendDetails", ImVec2(0, 0), true);
-    PopStyleVar();
+	BeginChild("##FriendDetails", ImVec2(0, 0), true);
+	PopStyleVar();
 
-    if (g_selectedFriendIdx < 0 || g_selectedFriendIdx >= static_cast<int>(g_friends.size())) {
-        Indent(desiredTextIndent);
-        TextWrapped("Click a friend to see more details or take action.");
-        Unindent(desiredTextIndent);
-    } else if (g_friendDetailsLoading.load()) {
-        Indent(desiredTextIndent);
-        Text("Loading full details...");
-        Unindent(desiredTextIndent);
-    } else {
-        const auto &D = g_selectedFriend;
-        if (D.id == 0 && g_friends[g_selectedFriendIdx].id != 0) {
-            Indent(desiredTextIndent);
-            Text("Fetching details for %s...", g_friends[g_selectedFriendIdx].username.c_str());
+	if (g_selectedFriendIdx < 0 || g_selectedFriendIdx >= static_cast<int>(g_friends.size())) {
+		Indent(desiredTextIndent);
+		TextWrapped("Click a friend to see more details or take action.");
+		Unindent(desiredTextIndent);
+	} else if (g_friendDetailsLoading.load()) {
+		Indent(desiredTextIndent);
+		Text("Loading full details...");
+		Unindent(desiredTextIndent);
+	} else {
+		const auto &D = g_selectedFriend;
+		if (D.id == 0 && g_friends[g_selectedFriendIdx].id != 0) {
+			Indent(desiredTextIndent);
+			Text("Fetching details for %s...", g_friends[g_selectedFriendIdx].username.c_str());
 
-            Unindent(desiredTextIndent);
-        } else if (D.id == 0) {
-            Indent(desiredTextIndent);
-            TextWrapped("Details not available or selection issue.");
-            Unindent(desiredTextIndent);
-        } else {
-            ImGuiTableFlags tableFlags = ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_RowBg |
-                                         ImGuiTableFlags_SizingFixedFit;
-            PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(0.0f, 4.0f));
-            if (BeginTable("FriendInfoTable", 2, tableFlags)) {
-                TableSetupColumn("##friendlabel", ImGuiTableColumnFlags_WidthFixed, 120.f);
-                TableSetupColumn("##friendvalue", ImGuiTableColumnFlags_WidthStretch);
+			Unindent(desiredTextIndent);
+		} else if (D.id == 0) {
+			Indent(desiredTextIndent);
+			TextWrapped("Details not available or selection issue.");
+			Unindent(desiredTextIndent);
+		} else {
+			ImGuiTableFlags tableFlags = ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_RowBg |
+			                             ImGuiTableFlags_SizingFixedFit;
+			PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(0.0f, 4.0f));
+			if (BeginTable("FriendInfoTable", 2, tableFlags)) {
+				TableSetupColumn("##friendlabel", ImGuiTableColumnFlags_WidthFixed, 120.f);
+				TableSetupColumn("##friendvalue", ImGuiTableColumnFlags_WidthStretch);
 
-                auto addFriendDataRow = [&](const char *label, const string &value, bool isWrapped = false) {
-                    TableNextRow();
-                    TableSetColumnIndex(0);
-                    Indent(desiredTextIndent);
-                    Spacing();
-                    TextUnformatted(label);
-                    Spacing();
-                    Unindent(desiredTextIndent);
+				auto addFriendDataRow = [&](const char *label, const string &value, bool isWrapped = false) {
+					TableNextRow();
+					TableSetColumnIndex(0);
+					Indent(desiredTextIndent);
+					Spacing();
+					TextUnformatted(label);
+					Spacing();
+					Unindent(desiredTextIndent);
 
-                    TableSetColumnIndex(1);
-                    Indent(desiredTextIndent);
-                    Spacing();
-                    PushID(label);
-                    if (isWrapped) {
-                        TextWrapped("%s", value.c_str());
-                    } else {
-                        TextUnformatted(value.c_str());
-                    }
-                    if (BeginPopupContextItem("CopyFriendValue")) {
-                        if (MenuItem("Copy")) {
-                            SetClipboardText(value.c_str());
-                        }
-                        EndPopup();
-                    }
-                    PopID();
-                    Spacing();
-                    Unindent(desiredTextIndent);
-                };
+					TableSetColumnIndex(1);
+					Indent(desiredTextIndent);
+					Spacing();
+					PushID(label);
+					if (isWrapped) {
+						TextWrapped("%s", value.c_str());
+					} else {
+						TextUnformatted(value.c_str());
+					}
+					if (BeginPopupContextItem("CopyFriendValue")) {
+						if (MenuItem("Copy")) {
+							SetClipboardText(value.c_str());
+						}
+						EndPopup();
+					}
+					PopID();
+					Spacing();
+					Unindent(desiredTextIndent);
+				};
 
-                auto addFriendDataRowInt = [&](const char *label, int value) {
-                    addFriendDataRow(label, to_string(value));
-                };
+				auto addFriendDataRowInt = [&](const char *label, int value) {
+					addFriendDataRow(label, to_string(value));
+				};
 
-                addFriendDataRow("User ID:", to_string(D.id));
-                addFriendDataRow("Username:", D.username);
-                addFriendDataRow("Display Name:", D.displayName.empty() ? D.username : D.displayName);
-                addFriendDataRow("Created:", formatPrettyDate(D.createdIso));
-                addFriendDataRowInt("Followers:", D.followers);
-                addFriendDataRowInt("Following:", D.following);
+				addFriendDataRow("User ID:", to_string(D.id));
+				addFriendDataRow("Username:", D.username);
+				addFriendDataRow("Display Name:", D.displayName.empty() ? D.username : D.displayName);
+				addFriendDataRow("Created:", formatPrettyDate(D.createdIso));
+				addFriendDataRowInt("Followers:", D.followers);
+				addFriendDataRowInt("Following:", D.following);
 
-                TableNextRow();
-                TableSetColumnIndex(0);
-                Indent(desiredTextIndent);
-                Spacing();
-                TextUnformatted("Description:");
-                Spacing();
-                Unindent(desiredTextIndent);
+				TableNextRow();
+				TableSetColumnIndex(0);
+				Indent(desiredTextIndent);
+				Spacing();
+				TextUnformatted("Description:");
+				Spacing();
+				Unindent(desiredTextIndent);
 
-                TableSetColumnIndex(1);
-                Indent(desiredTextIndent);
-                Spacing();
+				TableSetColumnIndex(1);
+				Indent(desiredTextIndent);
+				Spacing();
 
-                ImGuiStyle &style = GetStyle();
+				ImGuiStyle &style = GetStyle();
 
-                float spaceForBottomSpacingInCell = style.ItemSpacing.y;
+				float spaceForBottomSpacingInCell = style.ItemSpacing.y;
 
-                float spaceForSeparator = style.ItemSpacing.y;
+				float spaceForSeparator = style.ItemSpacing.y;
 
-                float spaceForButtons = GetFrameHeightWithSpacing();
+				float spaceForButtons = GetFrameHeightWithSpacing();
 
-                float reservedHeightBelowDescContent = spaceForBottomSpacingInCell + spaceForSeparator +
-                                                       spaceForButtons;
+				float reservedHeightBelowDescContent = spaceForBottomSpacingInCell + spaceForSeparator +
+				                                       spaceForButtons;
 
-                float availableHeightForDescAndBelow = GetContentRegionAvail().y;
+				float availableHeightForDescAndBelow = GetContentRegionAvail().y;
 
-                float descChildHeight = availableHeightForDescAndBelow - reservedHeightBelowDescContent;
+				float descChildHeight = availableHeightForDescAndBelow - reservedHeightBelowDescContent;
 
-                float minDescHeight = GetTextLineHeightWithSpacing() * 3.0f;
-                if (descChildHeight < minDescHeight) {
-                    descChildHeight = minDescHeight;
-                }
+				float minDescHeight = GetTextLineHeightWithSpacing() * 3.0f;
+				if (descChildHeight < minDescHeight) {
+					descChildHeight = minDescHeight;
+				}
 
-                const string descStr = D.description.empty() ? "(No description)" : D.description;
-                PushID("FriendDesc");
-                BeginChild("##FriendDescScroll", ImVec2(0, descChildHeight - 4), false,
-                           ImGuiWindowFlags_HorizontalScrollbar);
-                TextWrapped("%s", descStr.c_str());
-                if (BeginPopupContextItem("CopyFriendDesc")) {
-                    if (MenuItem("Copy")) {
-                        SetClipboardText(descStr.c_str());
-                    }
-                    EndPopup();
-                }
-                EndChild();
-                PopID();
+				const string descStr = D.description.empty() ? "(No description)" : D.description;
+				PushID("FriendDesc");
+				BeginChild("##FriendDescScroll", ImVec2(0, descChildHeight - 4), false,
+				           ImGuiWindowFlags_HorizontalScrollbar);
+				TextWrapped("%s", descStr.c_str());
+				if (BeginPopupContextItem("CopyFriendDesc")) {
+					if (MenuItem("Copy")) {
+						SetClipboardText(descStr.c_str());
+					}
+					EndPopup();
+				}
+				EndChild();
+				PopID();
 
-                Spacing();
-                Unindent(desiredTextIndent);
+				Spacing();
+				Unindent(desiredTextIndent);
 
-                EndTable();
-            }
-            PopStyleVar();
+				EndTable();
+			}
+			PopStyleVar();
 
-            Separator();
+			Separator();
 
-            Indent(desiredTextIndent / 2);
-            const FriendInfo &row = g_friends[g_selectedFriendIdx];
+			Indent(desiredTextIndent / 2);
+			const FriendInfo &row = g_friends[g_selectedFriendIdx];
 
-            bool canJoin = (row.presence == "InGame" && row.placeId && !row.gameId.empty());
-            BeginDisabled(!canJoin);
-            if (Button((string(ICON_JOIN) + " Join Game").c_str()) && canJoin) {
-                vector<pair<int, string> > accounts;
-                for (int id: g_selectedAccountIds) {
-                    auto it = find_if(g_accounts.begin(), g_accounts.end(),
-                                      [&](const AccountData &a) { return a.id == id; });
-                    if (it != g_accounts.end())
-                        accounts.emplace_back(it->id, it->cookie);
-                }
-                if (!accounts.empty()) {
-                    Threading::newThread([row, accounts]() {
-                        launchRobloxSequential(row.placeId, row.gameId, accounts);
-                    });
-                }
-            }
+			bool canJoin = (row.presence == "InGame" && row.placeId && !row.gameId.empty());
+			BeginDisabled(!canJoin);
+			if (Button((string(ICON_JOIN) + " Join Game").c_str()) && canJoin) {
+				vector<pair<int, string> > accounts;
+				for (int id: g_selectedAccountIds) {
+					auto it = find_if(g_accounts.begin(), g_accounts.end(),
+					                  [&](const AccountData &a) { return a.id == id; });
+					if (it != g_accounts.end())
+						accounts.emplace_back(it->id, it->cookie);
+				}
+				if (!accounts.empty()) {
+					Threading::newThread([row, accounts]() {
+						launchRobloxSequential(row.placeId, row.gameId, accounts);
+					});
+				}
+			}
 
-            EndDisabled();
-            SameLine();
-            if (Button((string(ICON_OPEN_LINK) + " Open Profile").c_str())) {
-                if (D.id)
-                    LaunchWebview(
-                        "https://www.roblox.com/users/" + to_string(D.id) + "/profile",
-                        "Roblox Profile", acct.cookie);
-            }
-            SameLine();
-            if (Button((string(ICON_INVENTORY) + " Open Inventory").c_str())) {
-                if (D.id)
-                    LaunchWebview(
-                        "https://www.roblox.com/users/" + to_string(D.id) + "/inventory/#!/accessories",
-                        "Roblox Inventory", acct.cookie);
-            }
-            Unindent(desiredTextIndent / 2);
-        }
-    }
+			EndDisabled();
+			SameLine();
+			if (Button((string(ICON_OPEN_LINK) + " Open Profile").c_str())) {
+				if (D.id)
+					LaunchWebview(
+						"https://www.roblox.com/users/" + to_string(D.id) + "/profile",
+						"Roblox Profile", acct.cookie);
+			}
+			SameLine();
+			if (Button((string(ICON_INVENTORY) + " Open Inventory").c_str())) {
+				if (D.id)
+					LaunchWebview(
+						"https://www.roblox.com/users/" + to_string(D.id) + "/inventory/#!/accessories",
+						"Roblox Inventory", acct.cookie);
+			}
+			Unindent(desiredTextIndent / 2);
+		}
+	}
 
-    EndChild();
+	EndChild();
 }

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -209,9 +209,11 @@ void RenderFriendsTab() {
                 Separator();
                 if (f.presence == "InGame" && f.placeId && !f.gameId.empty()) {
                     if (MenuItem("Join")) {
-                        vector<pair<int, string>> accounts;
-                        for (int id : g_selectedAccountIds) {
-                            auto itA = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) { return a.id == id; });
+                        vector<pair<int, string> > accounts;
+                        for (int id: g_selectedAccountIds) {
+                            auto itA = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) {
+                                return a.id == id;
+                            });
                             if (itA != g_accounts.end())
                                 accounts.emplace_back(itA->id, itA->cookie);
                         }
@@ -229,16 +231,20 @@ void RenderFriendsTab() {
                     }
                     if (BeginMenu("Copy Launch Method")) {
                         char buf[256];
-                        snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)f.placeId, f.gameId.c_str());
+                        snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s",
+                                 (unsigned long long) f.placeId, f.gameId.c_str());
                         if (MenuItem("Deep Link")) SetClipboardText(buf);
-                        string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(f.placeId) + ", \"" + f.gameId + "\")";
+                        string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(f.placeId) + ", \"" + f.gameId +
+                                    "\")";
                         if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
-                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(f.placeId) + ", \"" + f.gameId + "\")";
+                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" +
+                                      to_string(f.placeId) + ", \"" + f.gameId + "\")";
                         if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
-                        EndMenu();
+                        ImGui::EndMenu();
                     }
                     if (MenuItem("Generate Invite Link")) {
-                        string link = "https://www.roblox.com/games/start?placeId=" + to_string(f.placeId) + "&gameInstanceId=" + f.gameId;
+                        string link = "https://www.roblox.com/games/start?placeId=" + to_string(f.placeId) +
+                                      "&gameInstanceId=" + f.gameId;
                         SetClipboardText(link.c_str());
                     }
                 }
@@ -257,7 +263,8 @@ void RenderFriendsTab() {
                             bool ok = RobloxApi::unfriend(to_string(friendId), cookieCopy, &resp);
                             if (ok) {
                                 erase_if(g_friends, [&](const FriendInfo &fi) { return fi.id == friendId; });
-                                if (g_selectedFriendIdx >= 0 && g_selectedFriendIdx < static_cast<int>(g_friends.size()) &&
+                                if (g_selectedFriendIdx >= 0 && g_selectedFriendIdx < static_cast<int>(g_friends.size())
+                                    &&
                                     g_friends[g_selectedFriendIdx].id == friendId) {
                                     g_selectedFriendIdx = -1;
                                     g_selectedFriend = {};
@@ -267,8 +274,8 @@ void RenderFriendsTab() {
                                 });
                                 auto &unfList = g_unfriendedFriends[acctIdCopy];
                                 if (std::none_of(unfList.begin(), unfList.end(), [&](const FriendInfo &fi) {
-                                        return fi.id == friendId;
-                                    }))
+                                    return fi.id == friendId;
+                                }))
                                     unfList.push_back(fCopy);
                                 Data::SaveFriends();
                             } else {

--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -227,6 +227,20 @@ void RenderFriendsTab() {
                     if (MenuItem("Copy Job ID")) {
                         SetClipboardText(f.gameId.c_str());
                     }
+                    if (BeginMenu("Copy Launch Method")) {
+                        char buf[256];
+                        snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)f.placeId, f.gameId.c_str());
+                        if (MenuItem("Deep Link")) SetClipboardText(buf);
+                        string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(f.placeId) + ", \"" + f.gameId + "\")";
+                        if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
+                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(f.placeId) + ", \"" + f.gameId + "\")";
+                        if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
+                        EndMenu();
+                    }
+                    if (MenuItem("Generate Invite Link")) {
+                        string link = "https://www.roblox.com/games/start?placeId=" + to_string(f.placeId) + "&gameInstanceId=" + f.gameId;
+                        SetClipboardText(link.c_str());
+                    }
                 }
                 Separator();
                 PushStyleColor(ImGuiCol_Text, ImVec4(1.f, 0.4f, 0.4f, 1.f));

--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -41,7 +41,7 @@ static mutex g_logs_mtx;
 static void clearLogs() {
     string dir = logsFolder();
     if (!dir.empty() && fs::exists(dir)) {
-        for (const auto &entry : fs::directory_iterator(dir)) {
+        for (const auto &entry: fs::directory_iterator(dir)) {
             if (entry.is_regular_file() && entry.path().extension() == ".log") {
                 error_code ec;
                 fs::remove(entry.path(), ec);
@@ -49,8 +49,7 @@ static void clearLogs() {
                     LOG_WARN("Failed to delete log: " + entry.path().string());
             }
         }
-    }
-    {
+    } {
         lock_guard<mutex> lk(g_logs_mtx);
         g_logs.clear();
         g_selected_log_idx = -1;
@@ -279,16 +278,20 @@ void RenderHistoryTab() {
                     }
                     if (BeginMenu("Copy Launch Method")) {
                         char buf[256];
-                        snprintf(buf, sizeof(buf), "roblox://placeId=%s&gameInstanceId=%s", logInfo.placeId.c_str(), logInfo.jobId.c_str());
+                        snprintf(buf, sizeof(buf), "roblox://placeId=%s&gameInstanceId=%s", logInfo.placeId.c_str(),
+                                 logInfo.jobId.c_str());
                         if (MenuItem("Deep Link")) SetClipboardText(buf);
-                        string js = "Roblox.GameLauncher.joinGameInstance(" + logInfo.placeId + ", \"" + logInfo.jobId + "\")";
+                        string js = "Roblox.GameLauncher.joinGameInstance(" + logInfo.placeId + ", \"" + logInfo.jobId +
+                                    "\")";
                         if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
-                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + logInfo.placeId + ", \"" + logInfo.jobId + "\")";
+                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + logInfo.placeId
+                                      + ", \"" + logInfo.jobId + "\")";
                         if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
-                        EndMenu();
+                        ImGui::EndMenu();
                     }
                     if (MenuItem("Generate Invite Link")) {
-                        string link = "https://www.roblox.com/games/start?placeId=" + logInfo.placeId + "&gameInstanceId=" + logInfo.jobId;
+                        string link = "https://www.roblox.com/games/start?placeId=" + logInfo.placeId +
+                                      "&gameInstanceId=" + logInfo.jobId;
                         SetClipboardText(link.c_str());
                     }
                     Separator();
@@ -327,19 +330,19 @@ void RenderHistoryTab() {
                     }
 
                     if (place_id_val > 0) {
-                        vector<pair<int, string>> accounts;
-                        for (int id : g_selectedAccountIds) {
+                        vector<pair<int, string> > accounts;
+                        for (int id: g_selectedAccountIds) {
                             auto it = find_if(g_accounts.begin(), g_accounts.end(),
-                                             [&](const AccountData &a) { return a.id == id; });
+                                              [&](const AccountData &a) { return a.id == id; });
                             if (it != g_accounts.end())
                                 accounts.emplace_back(it->id, it->cookie);
                         }
                         if (!accounts.empty()) {
                             LOG_INFO("Launching game from history...");
                             thread([place_id_val, jobId = logInfo.jobId, accounts]() {
-                                      launchRobloxSequential(place_id_val, jobId, accounts);
-                                  })
-                                .detach();
+                                        launchRobloxSequential(place_id_val, jobId, accounts);
+                                    })
+                                    .detach();
                         } else {
                             LOG_INFO("Selected account not found.");
                         }

--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -269,6 +269,32 @@ void RenderHistoryTab() {
             PushID(i);
             if (Selectable(niceLabel(logInfo).c_str(), g_selected_log_idx == i))
                 g_selected_log_idx = i;
+            if (BeginPopupContextItem("HistoryRowCtx")) {
+                if (!logInfo.placeId.empty() && !logInfo.jobId.empty()) {
+                    if (MenuItem("Copy Place ID")) {
+                        SetClipboardText(logInfo.placeId.c_str());
+                    }
+                    if (MenuItem("Copy Job ID")) {
+                        SetClipboardText(logInfo.jobId.c_str());
+                    }
+                    if (BeginMenu("Copy Launch Method")) {
+                        char buf[256];
+                        snprintf(buf, sizeof(buf), "roblox://placeId=%s&gameInstanceId=%s", logInfo.placeId.c_str(), logInfo.jobId.c_str());
+                        if (MenuItem("Deep Link")) SetClipboardText(buf);
+                        string js = "Roblox.GameLauncher.joinGameInstance(" + logInfo.placeId + ", \"" + logInfo.jobId + "\")";
+                        if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
+                        string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + logInfo.placeId + ", \"" + logInfo.jobId + "\")";
+                        if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
+                        EndMenu();
+                    }
+                    if (MenuItem("Generate Invite Link")) {
+                        string link = "https://www.roblox.com/games/start?placeId=" + logInfo.placeId + "&gameInstanceId=" + logInfo.jobId;
+                        SetClipboardText(link.c_str());
+                    }
+                    Separator();
+                }
+                EndPopup();
+            }
             PopID();
         }
 

--- a/components/servers/servers_tab.cpp
+++ b/components/servers/servers_tab.cpp
@@ -220,6 +220,23 @@ void RenderServersTab() {
                 if (MenuItem("Copy Job ID")) {
                     SetClipboardText(srv.jobId.c_str());
                 }
+                if (MenuItem("Copy Place ID")) {
+                    SetClipboardText(to_string(g_current_placeId_servers).c_str());
+                }
+                if (BeginMenu("Copy Launch Method")) {
+                    char buf[256];
+                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)g_current_placeId_servers, srv.jobId.c_str());
+                    if (MenuItem("Deep Link")) SetClipboardText(buf);
+                    string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(g_current_placeId_servers) + ", \"" + srv.jobId + "\")";
+                    if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
+                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(g_current_placeId_servers) + ", \"" + srv.jobId + "\")";
+                    if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
+                    EndMenu();
+                }
+                if (MenuItem("Generate Invite Link")) {
+                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(g_current_placeId_servers) + "&gameInstanceId=" + srv.jobId;
+                    SetClipboardText(link.c_str());
+                }
                 Separator();
                 if (MenuItem("Join Server")) {
                     if (!g_selectedAccountIds.empty()) {

--- a/components/servers/servers_tab.cpp
+++ b/components/servers/servers_tab.cpp
@@ -190,19 +190,19 @@ void RenderServersTab() {
                            ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowItemOverlap,
                            ImVec2(0, row_interaction_height))) {
                 if (!g_selectedAccountIds.empty()) {
-                    vector<pair<int, string>> accounts;
-                    for (int id : g_selectedAccountIds) {
+                    vector<pair<int, string> > accounts;
+                    for (int id: g_selectedAccountIds) {
                         auto it = find_if(g_accounts.begin(), g_accounts.end(),
-                                         [&](const AccountData &a) { return a.id == id; });
+                                          [&](const AccountData &a) { return a.id == id; });
                         if (it != g_accounts.end())
                             accounts.emplace_back(it->id, it->cookie);
                     }
                     if (!accounts.empty()) {
                         LOG_INFO("Joining server (left-click)...");
                         thread([accounts, pId = g_current_placeId_servers, jId = srv.jobId]() {
-                                  launchRobloxSequential(pId, jId, accounts);
-                              })
-                            .detach();
+                                    launchRobloxSequential(pId, jId, accounts);
+                                })
+                                .detach();
                     } else {
                         LOG_INFO("Selected account not found.");
                     }
@@ -225,34 +225,38 @@ void RenderServersTab() {
                 }
                 if (BeginMenu("Copy Launch Method")) {
                     char buf[256];
-                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s", (unsigned long long)g_current_placeId_servers, srv.jobId.c_str());
+                    snprintf(buf, sizeof(buf), "roblox://placeId=%llu&gameInstanceId=%s",
+                             (unsigned long long) g_current_placeId_servers, srv.jobId.c_str());
                     if (MenuItem("Deep Link")) SetClipboardText(buf);
-                    string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(g_current_placeId_servers) + ", \"" + srv.jobId + "\")";
+                    string js = "Roblox.GameLauncher.joinGameInstance(" + to_string(g_current_placeId_servers) + ", \""
+                                + srv.jobId + "\")";
                     if (MenuItem("JavaScript")) SetClipboardText(js.c_str());
-                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(g_current_placeId_servers) + ", \"" + srv.jobId + "\")";
+                    string luau = "game:GetService(\"TeleportService\"):TeleportToPlaceInstance(" + to_string(
+                                      g_current_placeId_servers) + ", \"" + srv.jobId + "\")";
                     if (MenuItem("ROBLOX Luau")) SetClipboardText(luau.c_str());
-                    EndMenu();
+                    ImGui::EndMenu();
                 }
                 if (MenuItem("Generate Invite Link")) {
-                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(g_current_placeId_servers) + "&gameInstanceId=" + srv.jobId;
+                    string link = "https://www.roblox.com/games/start?placeId=" + to_string(g_current_placeId_servers) +
+                                  "&gameInstanceId=" + srv.jobId;
                     SetClipboardText(link.c_str());
                 }
                 Separator();
                 if (MenuItem("Join Server")) {
                     if (!g_selectedAccountIds.empty()) {
-                        vector<pair<int, string>> accounts;
-                        for (int id : g_selectedAccountIds) {
+                        vector<pair<int, string> > accounts;
+                        for (int id: g_selectedAccountIds) {
                             auto it = find_if(g_accounts.begin(), g_accounts.end(),
-                                             [&](const AccountData &a) { return a.id == id; });
+                                              [&](const AccountData &a) { return a.id == id; });
                             if (it != g_accounts.end())
                                 accounts.emplace_back(it->id, it->cookie);
                         }
                         if (!accounts.empty()) {
                             LOG_INFO("Joining server (context menu)...");
                             thread([accounts, pId = g_current_placeId_servers, jId = srv.jobId]() {
-                                      launchRobloxSequential(pId, jId, accounts);
-                                  })
-                                .detach();
+                                        launchRobloxSequential(pId, jId, accounts);
+                                    })
+                                    .detach();
                         } else {
                             LOG_INFO("Selected account not found.");
                         }

--- a/main.cpp
+++ b/main.cpp
@@ -175,7 +175,8 @@ int WINAPI WinMain(
     UINT dpi = GetDpiForSystem();
     int width = MulDiv(950, dpi, 96);
     int height = MulDiv(600, dpi, 96);
-    HWND hwnd = ::CreateWindowW(wc.lpszClassName, L"AltMan", WS_OVERLAPPEDWINDOW, 100, 100, width, height, nullptr, nullptr,
+    HWND hwnd = ::CreateWindowW(wc.lpszClassName, L"AltMan", WS_OVERLAPPEDWINDOW, 100, 100, width, height, nullptr,
+                                nullptr,
                                 hInstance,
                                 nullptr);
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -86,8 +86,27 @@ bool RenderUI() {
         PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(8, 8));
         PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
 
-        if (Begin("StatusBar", nullptr, flags))
-            Text("Status: %s", Status::Get().c_str());
+        if (Begin("StatusBar", nullptr, flags)) {
+            string selectedNames;
+            bool first = true;
+            for (int id : g_selectedAccountIds) {
+                auto it = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) { return a.id == id; });
+                if (it == g_accounts.end())
+                    continue;
+                if (!first)
+                    selectedNames += ", ";
+                string name = it->displayName.empty() ? it->username : it->displayName;
+                if (first && id == g_defaultAccountId)
+                    name += "*";
+                selectedNames += name;
+                first = false;
+            }
+
+            if (selectedNames.empty())
+                Text("Status: %s", Status::Get().c_str());
+            else
+                Text("Selected: %s | Status: %s", selectedNames.c_str(), Status::Get().c_str());
+        }
         End();
         PopStyleVar(2);
     }

--- a/ui.cpp
+++ b/ui.cpp
@@ -89,8 +89,9 @@ bool RenderUI() {
         if (Begin("StatusBar", nullptr, flags)) {
             string selectedNames;
             bool first = true;
-            for (int id : g_selectedAccountIds) {
-                auto it = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a) { return a.id == id; });
+            for (int id: g_selectedAccountIds) {
+                auto it = find_if(g_accounts.begin(), g_accounts.end(),
+                                  [&](const AccountData &a) { return a.id == id; });
                 if (it == g_accounts.end())
                     continue;
                 if (!first)

--- a/utils/launcher.hpp
+++ b/utils/launcher.hpp
@@ -15,15 +15,15 @@ using namespace std;
 using namespace std::chrono;
 
 static string urlEncode(const string &s) {
-        ostringstream out;
-        out << hex << uppercase;
-        for (unsigned char c: s) {
-                if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
-                        out << c;
-                else
-                        out << '%' << setw(2) << setfill('0') << static_cast<int>(c);
-        }
-        return out.str();
+	ostringstream out;
+	out << hex << uppercase;
+	for (unsigned char c: s) {
+		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+			out << c;
+		else
+			out << '%' << setw(2) << setfill('0') << static_cast<int>(c);
+	}
+	return out.str();
 }
 
 inline HANDLE startRoblox(uint64_t placeId, const string &jobId, const string &cookie) {
@@ -115,21 +115,22 @@ inline HANDLE startRoblox(uint64_t placeId, const string &jobId, const string &c
 	LOG_INFO("Roblox process started successfully for place ID: " + to_string(placeId));
 	return executionInfo.hProcess;
 }
+
 inline void launchRobloxSequential(uint64_t placeId, const std::string &jobId,
-                                   const std::vector<std::pair<int, std::string>> &accounts) {
-    for (const auto &[accountId, cookie] : accounts) {
-        LOG_INFO("Launching Roblox for account ID: " + std::to_string(accountId) +
-                 " PlaceID: " + std::to_string(placeId) +
-                 (jobId.empty() ? "" : " JobID: " + jobId));
-        HANDLE proc = startRoblox(placeId, jobId, cookie);
-        if (proc) {
-            WaitForInputIdle(proc, INFINITE);
-            CloseHandle(proc);
-            LOG_INFO("Roblox launched successfully for account ID: " +
-                     std::to_string(accountId));
-        } else {
-            LOG_ERROR("Failed to start Roblox for account ID: " +
-                      std::to_string(accountId));
-        }
-    }
+                                   const std::vector<std::pair<int, std::string> > &accounts) {
+	for (const auto &[accountId, cookie]: accounts) {
+		LOG_INFO("Launching Roblox for account ID: " + std::to_string(accountId) +
+			" PlaceID: " + std::to_string(placeId) +
+			(jobId.empty() ? "" : " JobID: " + jobId));
+		HANDLE proc = startRoblox(placeId, jobId, cookie);
+		if (proc) {
+			WaitForInputIdle(proc, INFINITE);
+			CloseHandle(proc);
+			LOG_INFO("Roblox launched successfully for account ID: " +
+				std::to_string(accountId));
+		} else {
+			LOG_ERROR("Failed to start Roblox for account ID: " +
+				std::to_string(accountId));
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- show selected accounts in status bar
- extend account context menu with browser links, invite helpers, and custom URL prompt
- allow copying various launch methods for friends, servers and history sessions

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cpr")*

------
https://chatgpt.com/codex/tasks/task_b_684b7d7d51dc8320a42b6338c4ee332c