### PR TITLE
Improve History tab context behaviour

### DIFF
--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -285,8 +285,8 @@ void RenderHistoryTab() {
             PushID(i);
             if (Selectable(niceLabel(logInfo).c_str(), g_selected_log_idx == i))
                 g_selected_log_idx = i;
-            if (BeginPopupContextItem("HistoryRowCtx")) {
-                if (!logInfo.placeId.empty() && !logInfo.jobId.empty()) {
+            if (!logInfo.placeId.empty() && !logInfo.jobId.empty() &&
+                BeginPopupContextItem("HistoryRowCtx")) {
                     if (MenuItem("Copy Place ID")) {
                         SetClipboardText(logInfo.placeId.c_str());
                     }
@@ -338,8 +338,9 @@ void RenderHistoryTab() {
             Separator();
 
             Indent(desiredTextIndent / 2);
-            if (Button("Launch this game session")) {
-                if (!logInfo.placeId.empty() && !g_selectedAccountIds.empty()) {
+            bool canLaunch = !logInfo.placeId.empty() && !logInfo.jobId.empty() &&
+                             !g_selectedAccountIds.empty();
+            if (canLaunch && Button("Launch this game session")) {
                     uint64_t place_id_val = 0;
                     try {
                         place_id_val = stoull(logInfo.placeId);
@@ -366,16 +367,6 @@ void RenderHistoryTab() {
                     } else {
                         LOG_INFO("Invalid Place ID in log.");
                     }
-                } else {
-                    LOG_INFO("Place ID missing or no account selected.");
-                    if (g_selectedAccountIds.empty()) {
-                        Status::Error("No account selected to open log entry.");
-                        ModalPopup::Add("Select an account first.");
-                    } else {
-                        Status::Error("Invalid log entry.");
-                        ModalPopup::Add("Invalid log entry.");
-                    }
-                }
             }
 
             Separator();


### PR DESCRIPTION
## Summary
- disable context menu for log entries without place and job IDs
- show **Launch this game session** button only when a selected log has both IDs and an account is selected

## Testing
- `g++ -std=c++17 -Ivendor/ImGui -Ivendor -I. -fsyntax-only components/history/history_tab.cpp` *(fails: `cpr/cpr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850c8972ea48320821da05a59a0b4f6