### PR TITLE
Fix history tab context menu and launch button conditions

### DIFF
--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -285,8 +285,8 @@ void RenderHistoryTab() {
             PushID(i);
             if (Selectable(niceLabel(logInfo).c_str(), g_selected_log_idx == i))
                 g_selected_log_idx = i;
-            if (BeginPopupContextItem("HistoryRowCtx")) {
-                if (!logInfo.placeId.empty() && !logInfo.jobId.empty()) {
+            if (!logInfo.placeId.empty() && !logInfo.jobId.empty() &&
+                BeginPopupContextItem("HistoryRowCtx")) {
                     if (MenuItem("Copy Place ID")) {
                         SetClipboardText(logInfo.placeId.c_str());
                     }
@@ -338,7 +338,9 @@ void RenderHistoryTab() {
             Separator();
 
             Indent(desiredTextIndent / 2);
-            if (Button("Launch this game session")) {
+            bool canLaunch = !logInfo.placeId.empty() && !logInfo.jobId.empty() &&
+                             !g_selectedAccountIds.empty();
+            if (canLaunch && Button("Launch this game session")) {
                 if (!logInfo.placeId.empty() && !g_selectedAccountIds.empty()) {
                     uint64_t place_id_val = 0;
                     try {


### PR DESCRIPTION
## Summary
- disable right click on history entries that lack place or job ids
- only show the "Launch this game session" button when the entry has both IDs and an account is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850ca71bb6c8320a2e7a31252148d66