### PR TITLE
Add update checker feature

### DIFF
--- a/components/data.cpp
+++ b/components/data.cpp
@@ -30,6 +30,7 @@ int g_defaultAccountId = -1;
 array<char, 128> s_jobIdBuffer = {};
 array<char, 128> s_playerBuffer = {};
 int g_statusRefreshInterval = 1;
+bool g_checkUpdatesOnStartup = true;
 
 vector<BYTE> encryptData(const string &plainText) {
     DATA_BLOB DataIn;
@@ -234,8 +235,10 @@ namespace Data {
             fin >> j;
             g_defaultAccountId = j.value("defaultAccountId", -1);
             g_statusRefreshInterval = j.value("statusRefreshInterval", 1);
+            g_checkUpdatesOnStartup = j.value("checkUpdatesOnStartup", true);
             LOG_INFO("Default account ID = " + std::to_string(g_defaultAccountId));
             LOG_INFO("Status refresh interval = " + std::to_string(g_statusRefreshInterval));
+            LOG_INFO("Check updates on startup = " + std::string(g_checkUpdatesOnStartup ? "true" : "false"));
         } catch (const std::exception &e) {
             LOG_ERROR("Failed to parse " + filename + ": " + e.what());
         }
@@ -245,6 +248,7 @@ namespace Data {
         nlohmann::json j;
         j["defaultAccountId"] = g_defaultAccountId;
         j["statusRefreshInterval"] = g_statusRefreshInterval;
+        j["checkUpdatesOnStartup"] = g_checkUpdatesOnStartup;
         std::ofstream out{filename};
         if (!out.is_open()) {
             LOG_ERROR("Could not open " + filename + " for writing");
@@ -253,6 +257,7 @@ namespace Data {
         out << j.dump(4);
         LOG_INFO("Saved defaultAccountId=" + std::to_string(g_defaultAccountId));
         LOG_INFO("Saved statusRefreshInterval=" + std::to_string(g_statusRefreshInterval));
+        LOG_INFO("Saved checkUpdatesOnStartup=" + std::string(g_checkUpdatesOnStartup ? "true" : "false"));
     }
 
     void LoadFriends(const std::string &filename) {

--- a/components/data.h
+++ b/components/data.h
@@ -50,6 +50,7 @@ extern ImVec4 g_accentColor;
 
 extern int g_defaultAccountId;
 extern int g_statusRefreshInterval;
+extern bool g_checkUpdatesOnStartup;
 extern std::array<char, 128> s_jobIdBuffer;
 extern std::array<char, 128> s_playerBuffer;
 

--- a/components/settings/settings_tab.cpp
+++ b/components/settings/settings_tab.cpp
@@ -56,6 +56,13 @@ void RenderSettingsTab()
                                 Data::SaveSettings("settings.json");
                         }
                 }
+
+                bool checkUpdates = g_checkUpdatesOnStartup;
+                if (Checkbox("Check for updates on startup", &checkUpdates))
+                {
+                        g_checkUpdatesOnStartup = checkUpdates;
+                        Data::SaveSettings("settings.json");
+                }
         }
         else
         {

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "utils/logging.hpp"
 #include "utils/confirm.h"
 #include "utils/main_thread.h"
+#include "utils/update.h"
 #include <cstdio>
 #include <thread>
 #include <chrono>
@@ -122,6 +123,9 @@ int WINAPI WinMain(
     }
 
     Data::LoadSettings("settings.json");
+    if (g_checkUpdatesOnStartup) {
+        CheckForUpdates();
+    }
     Data::LoadAccounts("accounts.json");
     Data::LoadFriends("friends.json");
 

--- a/utils/update.h
+++ b/utils/update.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <string>
+#include <windows.h>
+#include <nlohmann/json.hpp>
+#include "http.hpp"
+#include "logging.hpp"
+#include "main_thread.h"
+#include "confirm.h"
+#include "threading.h"
+#include "../version.h"
+
+inline void CheckForUpdates() {
+    Threading::newThread([]() {
+        const std::string url = "https://api.github.com/repos/crowsyndrome/altman/releases/latest";
+        auto resp = HttpClient::get(url, {{"User-Agent","AltMan"}, {"Accept","application/vnd.github+json"}});
+        if (resp.status_code != 200) {
+            LOG_ERROR("Failed to check for updates: HTTP " + std::to_string(resp.status_code));
+            return;
+        }
+        nlohmann::json j = HttpClient::decode(resp);
+        std::string latest = j.value("tag_name", "");
+        std::string html = j.value("html_url", "");
+        if (!latest.empty() && (latest[0]=='v' || latest[0]=='V'))
+            latest = latest.substr(1);
+        if (!latest.empty() && latest != APP_VERSION) {
+            MainThread::Post([latest, html]() {
+                std::string msg = "A new version (" + latest + ") is available. Download?";
+                ConfirmPopup::Add(msg, [html]() {
+                    ShellExecuteA(NULL, "open", html.c_str(), NULL, NULL, SW_SHOWNORMAL);
+                });
+            });
+        }
+    });
+}

--- a/version.h
+++ b/version.h
@@ -1,0 +1,2 @@
+#pragma once
+constexpr const char* APP_VERSION = "0.1.0";


### PR DESCRIPTION
## Summary
- add version header with `APP_VERSION`
- introduce update checker and call it on startup if enabled
- persist new `checkUpdatesOnStartup` option in settings
- expose checkbox in Settings tab to toggle automatic update checks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850d15ab3288320b5ff64039480ac3b