### PR TITLE
Add spacing to detail placeholders

### DIFF
--- a/components/friends/friends_tab.cpp
+++ b/components/friends/friends_tab.cpp
@@ -337,21 +337,25 @@ void RenderFriendsTab() {
 
     if (g_selectedFriendIdx < 0 || g_selectedFriendIdx >= static_cast<int>(g_friends.size())) {
         Indent(desiredTextIndent);
+        Spacing();
         TextWrapped("Click a friend to see more details or take action.");
         Unindent(desiredTextIndent);
     } else if (g_friendDetailsLoading.load()) {
         Indent(desiredTextIndent);
+        Spacing();
         Text("Loading full details...");
         Unindent(desiredTextIndent);
     } else {
         const auto &D = g_selectedFriend;
         if (D.id == 0 && g_friends[g_selectedFriendIdx].id != 0) {
             Indent(desiredTextIndent);
+            Spacing();
             Text("Fetching details for %s...", g_friends[g_selectedFriendIdx].username.c_str());
 
             Unindent(desiredTextIndent);
         } else if (D.id == 0) {
             Indent(desiredTextIndent);
+            Spacing();
             TextWrapped("Details not available or selection issue.");
             Unindent(desiredTextIndent);
         } else {

--- a/components/games/games_tab.cpp
+++ b/components/games/games_tab.cpp
@@ -448,6 +448,7 @@ static void RenderGameDetailsPanel(float panelWidth, float availableHeight) {
         Unindent(desiredTextIndent / 2);
     } else {
         Indent(desiredTextIndent);
+        Spacing();
         TextWrapped("Select a game from the list to see details or add a favorite.");
         Unindent(desiredTextIndent);
     }

--- a/components/history/history_tab.cpp
+++ b/components/history/history_tab.cpp
@@ -390,6 +390,7 @@ void RenderHistoryTab() {
         }
     } else {
         Indent(desiredTextIndent);
+        Spacing();
         TextWrapped("Select a log from the list to see details or launch the session.");
         Unindent(desiredTextIndent);
     }


### PR DESCRIPTION
## Summary
- add top spacing for empty friend, game, and log detail panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850d7327db08320ad8cf454e6892ba6