### PR TITLE
Add Fill Join Options menu action

### DIFF
--- a/src/components/accounts/accounts_join_ui.cpp
+++ b/src/components/accounts/accounts_join_ui.cpp
@@ -66,6 +66,18 @@ static const char *GetJoinHintLocal(int idx) {
 }
 
 
+void FillJoinOptions(uint64_t placeId, const std::string &jobId) {
+    snprintf(join_value_buf, sizeof(join_value_buf), "%llu", (unsigned long long)placeId);
+    if (jobId.empty()) {
+        join_jobid_buf[0] = '\0';
+        join_type_combo_index = 0;
+    } else {
+        snprintf(join_jobid_buf, sizeof(join_jobid_buf), "%s", jobId.c_str());
+        join_type_combo_index = 1;
+    }
+    g_activeTab = Tab_Accounts;
+}
+
 void RenderJoinOptions() {
     Spacing();
     Text("Join Options");

--- a/src/components/accounts/accounts_join_ui.h
+++ b/src/components/accounts/accounts_join_ui.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 
 void RenderJoinOptions();
 

--- a/src/components/accounts/accounts_join_ui.h
+++ b/src/components/accounts/accounts_join_ui.h
@@ -1,3 +1,5 @@
 #pragma once
 
 void RenderJoinOptions();
+
+void FillJoinOptions(uint64_t placeId, const std::string &jobId);

--- a/src/components/friends/friends_tab.cpp
+++ b/src/components/friends/friends_tab.cpp
@@ -16,6 +16,7 @@
 #include "ui/webview.hpp"
 #include "../games/games_utils.h"
 #include "ui/confirm.h"
+#include "../accounts/accounts_join_ui.h"
 
 using namespace ImGui;
 using namespace std;
@@ -214,6 +215,9 @@ void RenderFriendsTab() {
                                 launchRobloxSequential(row.placeId, row.gameId, accounts);
                             });
                         }
+                    }
+                    if (MenuItem("Fill Join Options")) {
+                        FillJoinOptions(f.placeId, f.gameId);
                     }
                     if (MenuItem("Copy Place ID")) {
                         SetClipboardText(to_string(f.placeId).c_str());

--- a/src/components/servers/servers_tab.cpp
+++ b/src/components/servers/servers_tab.cpp
@@ -21,6 +21,7 @@
 #include "system/launcher.hpp"
 #include "ui/modal_popup.h"
 #include "../../ui.h"
+#include "../accounts/accounts_join_ui.h"
 
 using namespace ImGui;
 using namespace std;
@@ -339,6 +340,9 @@ void RenderServersTab() {
                         Status::Error("No account selected to join server.");
                         ModalPopup::Add("Select an account first.");
                     }
+                }
+                if (MenuItem("Fill Join Options")) {
+                    FillJoinOptions(g_current_placeId_servers, srv.jobId);
                 }
                 EndPopup();
             }


### PR DESCRIPTION
## Summary
- expose `FillJoinOptions` helper next to join UI
- add the helper to friends and servers context menus

## Testing
- `g++ -std=c++17 -fsyntax-only src/components/accounts/accounts_join_ui.cpp` *(fails: imgui.h not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852238a51ec83208d5a4b07d631fc62