### PR TITLE
Add backup import/export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(APP_SRC
         src/components/servers/servers_tab.cpp
         src/components/servers/servers_utils.cpp
         src/components/settings/settings_tab.cpp
+        src/components/backup.cpp
         src/utils/ui/webview.hpp
 )
 

--- a/src/components/backup.cpp
+++ b/src/components/backup.cpp
@@ -1,0 +1,164 @@
+#include "backup.h"
+#include "data.h"
+#include "utils/core/logging.hpp"
+#include "utils/system/threading.h"
+#include "network/roblox.h"
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <filesystem>
+#include <ctime>
+
+using json = nlohmann::json;
+
+namespace {
+std::string xorEncrypt(const std::string &data, const std::string &password) {
+    std::string out = data;
+    for (size_t i = 0; i < out.size(); ++i) {
+        out[i] ^= password[i % password.size()];
+    }
+    return out;
+}
+
+std::string rleCompress(const std::string &data) {
+    std::string out;
+    for (size_t i = 0; i < data.size();) {
+        char c = data[i];
+        size_t j = i;
+        while (j < data.size() && data[j] == c && j - i < 255)
+            ++j;
+        out.push_back(c);
+        out.push_back(static_cast<char>(j - i));
+        i = j;
+    }
+    return out;
+}
+
+std::string rleDecompress(const std::string &data) {
+    std::string out;
+    for (size_t i = 0; i + 1 < data.size(); i += 2) {
+        char c = data[i];
+        unsigned char count = static_cast<unsigned char>(data[i + 1]);
+        out.append(count, c);
+    }
+    return out;
+}
+
+std::filesystem::path getBackupDir() {
+    std::filesystem::path dir = Data::StorageFilePath("backups");
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        LOG_ERROR("Failed to create backups directory: " + ec.message());
+    }
+    return dir;
+}
+
+std::string buildBackupPath() {
+    std::time_t t = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    char buf[64];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d-altman-backup.dat", &tm);
+    auto path = getBackupDir() / buf;
+    return path.string();
+}
+}
+
+bool Backup::Export(const std::string &password) {
+    json j;
+    // settings
+    {
+        std::ifstream in(Data::StorageFilePath("settings.json"));
+        if (in.is_open())
+            in >> j["settings"];
+        else
+            j["settings"] = json::object();
+    }
+    // accounts
+    json accounts = json::array();
+    for (const auto &acct : g_accounts) {
+        accounts.push_back({
+            {"id", acct.id},
+            {"cookie", acct.cookie},
+            {"note", acct.note},
+            {"isFavorite", acct.isFavorite}
+        });
+    }
+    j["accounts"] = std::move(accounts);
+    // favorites
+    {
+        std::ifstream in(Data::StorageFilePath("favorites.json"));
+        if (in.is_open())
+            in >> j["favorites"];
+        else
+            j["favorites"] = json::array();
+    }
+    std::string plain = j.dump();
+    std::string encrypted = xorEncrypt(plain, password);
+    std::string compressed = rleCompress(encrypted);
+    std::string path = buildBackupPath();
+    std::ofstream out(path, std::ios::binary);
+    if (!out.is_open()) {
+        LOG_ERROR("Failed to write backup");
+        return false;
+    }
+    out.write(compressed.data(), compressed.size());
+    return true;
+}
+
+bool Backup::Import(const std::string &file, const std::string &password, std::string *error) {
+    std::ifstream in(file, std::ios::binary);
+    if (!in.is_open()) {
+        LOG_ERROR("Failed to open backup file");
+        return false;
+    }
+    std::string compressed((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    std::string decrypted = xorEncrypt(rleDecompress(compressed), password);
+    json j;
+    try {
+        j = json::parse(decrypted);
+    } catch (...) {
+        if (error) *error = "Invalid password.";
+        LOG_ERROR("Invalid password.");
+        return false;
+    }
+    if (!j.contains("accounts") || !j["accounts"].is_array()) {
+        LOG_ERROR("Invalid backup format");
+        if (error && error->empty()) *error = "Invalid backup format";
+        return false;
+    }
+    g_accounts.clear();
+    for (auto &item : j["accounts"]) {
+        AccountData acct;
+        acct.id = item.value("id", 0);
+        acct.cookie = item.value("cookie", "");
+        acct.note = item.value("note", "");
+        acct.isFavorite = item.value("isFavorite", false);
+        uint64_t uid = Roblox::getUserId(acct.cookie);
+        acct.userId = std::to_string(uid);
+        acct.username = Roblox::getUsername(acct.cookie);
+        acct.displayName = Roblox::getDisplayName(acct.cookie);
+        acct.status = Roblox::getPresence(acct.cookie, uid);
+        auto vs = Roblox::getVoiceChatStatus(acct.cookie);
+        acct.voiceStatus = vs.status;
+        acct.voiceBanExpiry = vs.bannedUntil;
+        g_accounts.push_back(std::move(acct));
+    }
+    if (j.contains("settings")) {
+        std::ofstream s(Data::StorageFilePath("settings.json"));
+        s << j["settings"].dump(4);
+    }
+    if (j.contains("favorites")) {
+        std::ofstream f(Data::StorageFilePath("favorites.json"));
+        f << j["favorites"].dump(4);
+    }
+    Data::SaveAccounts();
+    Data::LoadAccounts();
+    Data::LoadSettings();
+    Data::LoadFavorites();
+    return true;
+}

--- a/src/components/backup.h
+++ b/src/components/backup.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace Backup {
+    bool Export(const std::string &password);
+    bool Import(const std::string &file, const std::string &password, std::string *error = nullptr);
+}

--- a/src/components/data.cpp
+++ b/src/components/data.cpp
@@ -445,4 +445,8 @@ namespace Data {
         out << arr.dump(4);
         LOG_INFO("Saved " + std::to_string(logs.size()) + " log entries");
     }
+
+    std::string StorageFilePath(const std::string &filename) {
+        return MakePath(filename);
+    }
 }

--- a/src/components/data.h
+++ b/src/components/data.h
@@ -75,7 +75,9 @@ namespace Data {
 
 	std::vector<LogInfo> LoadLogHistory(const std::string &filename = "log_history.json");
 
-	void SaveLogHistory(const std::vector<LogInfo> &logs, const std::string &filename = "log_history.json");
+        void SaveLogHistory(const std::vector<LogInfo> &logs, const std::string &filename = "log_history.json");
+
+        std::string StorageFilePath(const std::string &filename);
 }
 
 #endif

--- a/src/components/menu.cpp
+++ b/src/components/menu.cpp
@@ -58,7 +58,7 @@ bool RenderMainMenu() {
                         if (MenuItem("Import Backup")) {
                                 s_openImportPopup = true;
                         }
-                        EndMenu();
+                        ImGui::EndMenu();
                 }
 
                 if (BeginMenu("Accounts")) {


### PR DESCRIPTION
## Summary
- implement basic import/export system
- expose storage file path helper
- add UI for backup in the Utilities menu
- refine backup import/export UI

## Testing
- `cmake -S . -B build` (fails to find cpr package)
- `cmake --build build` (fails: no Makefile)
- `ctest` (no tests were found)


------
https://chatgpt.com/codex/tasks/task_e_686098d58b70832f8a72d40ee882fd01