### PR TITLE
Handles warned accounts like banned/terminated accounts

### DIFF
--- a/src/components/accounts/accounts_join_ui.cpp
+++ b/src/components/accounts/accounts_join_ui.cpp
@@ -150,7 +150,7 @@ void RenderJoinOptions() {
             for (int id: g_selectedAccountIds) {
                 auto it = std::find_if(g_accounts.begin(), g_accounts.end(),
                                        [id](auto &a) { return a.id == id; });
-                if (it != g_accounts.end() && it->status != "Banned" && it->status != "Terminated")
+                if (it != g_accounts.end() && it->status != "Banned" && it->status != "Warned" && it->status != "Terminated")
                     accounts.emplace_back(it->id, it->cookie);
             }
 

--- a/src/components/accounts/accounts_tab.cpp
+++ b/src/components/accounts/accounts_tab.cpp
@@ -97,7 +97,7 @@ void RenderAccountsTable(vector<AccountData> &accounts_to_display, const char *t
 			char selectable_label[64];
 			snprintf(selectable_label, sizeof(selectable_label), "##row_selectable_%d", account.id);
 
-			bool banned = account.status == "Banned";
+			bool banned = account.status == "Banned" || account.status == "Warned" || account.status == "Terminated";
 			if (Selectable(
 					selectable_label,
 					is_row_selected,

--- a/src/components/friends/friends_tab.cpp
+++ b/src/components/friends/friends_tab.cpp
@@ -76,7 +76,7 @@ void RenderFriendsTab()
     // Ensure the currently viewed account is valid and not banned.
     auto isCurrentViewAccount = [&](const AccountData &a)
     {
-        return a.id == g_viewAcctId && a.status != "Banned" && a.status != "Terminated";
+        return a.id == g_viewAcctId && a.status != "Banned" && a.status != "Warned" && a.status != "Terminated";
     };
 
     if (g_viewAcctId == -1 || std::none_of(g_accounts.begin(), g_accounts.end(), isCurrentViewAccount))
@@ -86,7 +86,7 @@ void RenderFriendsTab()
         for (int id : g_selectedAccountIds)
         {
             auto itSel = std::find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a)
-                                      { return a.id == id && a.status != "Banned" && a.status != "Terminated"; });
+                                      { return a.id == id && a.status != "Banned" && a.status != "Warned" && a.status != "Terminated"; });
             if (itSel != g_accounts.end())
             {
                 g_viewAcctId = id;
@@ -97,7 +97,7 @@ void RenderFriendsTab()
         if (g_viewAcctId == -1)
         {
             auto itFirst = std::find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a)
-                                        { return a.status != "Banned" && a.status != "Terminated"; });
+                                        { return a.status != "Banned" && a.status != "Warned" && a.status != "Terminated"; });
             if (itFirst != g_accounts.end())
                 g_viewAcctId = itFirst->id;
         }
@@ -138,8 +138,8 @@ void RenderFriendsTab()
         float maxLabelWidth = 0.0f;
         for (const auto &acc : g_accounts)
         {
-            if (acc.status == "Banned" || acc.status == "Terminated")
-                continue; // Skip banned and terminated accounts in the dropdown
+            if (acc.status == "Banned" || acc.status == "Warned" || acc.status == "Terminated")
+                continue; // Skip banned, warned and terminated accounts in the dropdown
             const string &labelStr = acc.displayName.empty() ? acc.username : acc.displayName;
             float w = CalcTextSize(labelStr.c_str()).x;
             if (w > maxLabelWidth)
@@ -157,8 +157,8 @@ void RenderFriendsTab()
         {
             for (const auto &acc : g_accounts)
             {
-                if (acc.status == "Banned" || acc.status == "Terminated")
-                    continue; // Skip banned and terminated accounts in the dropdown
+                if (acc.status == "Banned" || acc.status == "Warned" || acc.status == "Terminated")
+                    continue; // Skip banned, warned and terminated accounts in the dropdown
                 const char *label = acc.displayName.empty() ? acc.username.c_str() : acc.displayName.c_str();
                 bool isSelected = (acc.id == g_viewAcctId);
                 // Push a unique ID for each account item in the dropdown
@@ -310,7 +310,7 @@ void RenderFriendsTab()
                         for (int id : g_selectedAccountIds)
                         {
                             auto itA = find_if(g_accounts.begin(), g_accounts.end(), [&](const AccountData &a)
-                                               { return a.id == id && a.status != "Banned" && a.status != "Terminated"; });
+                                               { return a.id == id && a.status != "Banned" && a.status != "Warned" && a.status != "Terminated"; });
                             if (itA != g_accounts.end())
                                 accounts.emplace_back(itA->id, itA->cookie);
                         }
@@ -631,7 +631,7 @@ void RenderFriendsTab()
                 {
                     auto it = find_if(g_accounts.begin(), g_accounts.end(),
                                       [&](const AccountData &a)
-                                      { return a.id == id && a.status != "Banned" && a.status != "Terminated"; });
+                                      { return a.id == id && a.status != "Banned" && a.status != "Warned" && a.status != "Terminated"; });
                     if (it != g_accounts.end())
                         accounts.emplace_back(it->id, it->cookie);
                 }

--- a/src/components/games/games_tab.cpp
+++ b/src/components/games/games_tab.cpp
@@ -441,7 +441,7 @@ static void RenderGameDetailsPanel(float panelWidth, float availableHeight) {
                 for (int id: g_selectedAccountIds) {
                     auto it = find_if(g_accounts.begin(), g_accounts.end(),
                                       [&](const AccountData &a) { return a.id == id; });
-                    if (it != g_accounts.end() && it->status != "Banned" && it->status != "Terminated")
+                    if (it != g_accounts.end() && it->status != "Banned" && it->status != "Warned" && it->status != "Terminated")
                         accounts.emplace_back(it->id, it->cookie);
                 }
                 if (!accounts.empty()) {

--- a/src/components/history/history_tab.cpp
+++ b/src/components/history/history_tab.cpp
@@ -488,7 +488,7 @@ static void DisplayLogDetails(const LogInfo &logInfo) {
 							for (int id: g_selectedAccountIds) {
 									auto it = find_if(g_accounts.begin(), g_accounts.end(),
 													[&](const AccountData &a) { return a.id == id; });
-									if (it != g_accounts.end() && it->status != "Banned" && it->status != "Terminated")
+									if (it != g_accounts.end() && it->status != "Banned" && it->status != "Warned" && it->status != "Terminated")
 											accounts.emplace_back(it->id, it->cookie);
 							}
 							if (!accounts.empty()) {

--- a/src/components/menu.cpp
+++ b/src/components/menu.cpp
@@ -74,6 +74,12 @@ bool RenderMainMenu() {
                                                         acct.voiceBanExpiry = 0;
                                                         continue;
                                                 }
+                                                if (banStatus == Roblox::BanCheckResult::Warned) {
+                                                        acct.status = "Warned";
+                                                        acct.voiceStatus = "N/A";
+                                                        acct.voiceBanExpiry = 0;
+                                                        continue;  // Skip processing like banned accounts
+                                                }
                                                 if (banStatus == Roblox::BanCheckResult::Terminated) {
                                                         acct.status = "Terminated";
                                                         acct.voiceStatus = "N/A";

--- a/src/components/servers/servers_tab.cpp
+++ b/src/components/servers/servers_tab.cpp
@@ -291,7 +291,7 @@ void RenderServersTab()
                         auto it = find_if(g_accounts.begin(), g_accounts.end(),
                                           [&](const AccountData &a)
                                           { return a.id == id; });
-                        if (it != g_accounts.end() && it->status != "Banned" && it->status != "Terminated")
+                        if (it != g_accounts.end() && it->status != "Banned" && it->status != "Warned" && it->status != "Terminated")
                             accounts.emplace_back(it->id, it->cookie);
                     }
                     if (!accounts.empty())

--- a/src/components/settings/settings_tab.cpp
+++ b/src/components/settings/settings_tab.cpp
@@ -34,7 +34,7 @@ void RenderSettingsTab() {
 
                 int current_default_idx = -1;
                 for (size_t i = 0; i < g_accounts.size(); ++i) {
-                        if (g_accounts[i].status == "Banned" || g_accounts[i].status == "Terminated")
+                        if (g_accounts[i].status == "Banned" || g_accounts[i].status == "Warned" || g_accounts[i].status == "Terminated")
                                 continue; // Skip banned and terminated accounts
 
                         const char *labelPtr = g_accounts[i].displayName.c_str();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,10 @@ int WINAPI WinMain(
                 acct.status = "Banned";
                 acct.banExpiry = banInfo.endDate;
                 g_selectedAccountIds.erase(acct.id);
+            } else if (banInfo.status == Roblox::BanCheckResult::Warned) {
+                acct.status = "Warned";
+                acct.banExpiry = 0;
+                g_selectedAccountIds.erase(acct.id);  // Remove from selection like banned accounts
             } else if (banInfo.status == Roblox::BanCheckResult::Terminated) {
                 acct.status = "Terminated";
                 acct.banExpiry = 0; // Terminated accounts don't have an end date
@@ -238,6 +242,12 @@ int WINAPI WinMain(
                     acct.voiceStatus = "N/A";
                     acct.voiceBanExpiry = 0;
                     continue;
+                } else if (banInfo.status == Roblox::BanCheckResult::Warned) {
+                    acct.status = "Warned";
+                    acct.banExpiry = 0;
+                    acct.voiceStatus = "N/A";
+                    acct.voiceBanExpiry = 0;
+                    continue;  // Skip processing like banned accounts
                 } else if (banInfo.status == Roblox::BanCheckResult::Terminated) {
                     acct.status = "Terminated";
                     acct.banExpiry = 0;

--- a/src/utils/network/roblox/common.h
+++ b/src/utils/network/roblox/common.h
@@ -21,6 +21,9 @@ static ImVec4 getStatusColor(std::string statusCode) {
 	if (statusCode == "Banned") {
 		return ImVec4(1.0f, 0.3f, 0.3f, 1.0f);
 	}
+	if (statusCode == "Warned") {
+		return ImVec4(1.0f, 0.8f, 0.3f, 1.0f);  // Orange/yellow for warnings
+	}
 	if (statusCode == "Terminated") {
 		return ImVec4(0.8f, 0.1f, 0.1f, 1.0f);  // Darker red for terminated accounts
 	}

--- a/src/utils/network/roblox/session.h
+++ b/src/utils/network/roblox/session.h
@@ -59,14 +59,15 @@ namespace Roblox {
 	};
 
         static VoiceSettings getVoiceChatStatus(const std::string &cookie) {
-                // First check if account is banned/terminated
+                // First check if account is banned/warned/terminated
                 BanCheckResult status = cachedBanStatus(cookie);
                 if (status == BanCheckResult::Banned || 
+                    status == BanCheckResult::Warned ||
                     status == BanCheckResult::Terminated || 
                     status == BanCheckResult::InvalidCookie) {
                     return {"N/A", 0};
                 }
-
+                
                 LOG_INFO("Fetching voice chat settings");
                 auto resp = HttpClient::get(
                         "https://voice.roblox.com/v1/settings",

--- a/src/utils/network/roblox/social.h
+++ b/src/utils/network/roblox/social.h
@@ -191,7 +191,7 @@ namespace Roblox
 		if (!canUseCookie(cookie))
 		{
 			if (outResponse)
-				*outResponse = "Banned cookie";
+				*outResponse = "Banned/warned cookie";
 			return false;
 		}
 		std::string url = "https://friends.roblox.com/v1/users/" + targetUserId +
@@ -247,7 +247,7 @@ namespace Roblox
 		if (!canUseCookie(cookie))
 		{
 			if (outResponse)
-				*outResponse = "Banned cookie";
+				*outResponse = "Banned/warned cookie";
 			return false;
 		}
 		std::string url = "https://friends.roblox.com/v1/users/" + targetUserId +
@@ -287,7 +287,7 @@ namespace Roblox
 		if (!canUseCookie(cookie))
 		{
 			if (outResponse)
-				*outResponse = "Banned cookie";
+				*outResponse = "Banned/warned cookie";
 			return false;
 		}
 		std::string url = "https://friends.roblox.com/v1/users/" + targetUserId + "/follow";
@@ -319,7 +319,7 @@ namespace Roblox
 		if (!canUseCookie(cookie))
 		{
 			if (outResponse)
-				*outResponse = "Banned cookie";
+				*outResponse = "Banned/warned cookie";
 			return false;
 		}
 		std::string url = "https://friends.roblox.com/v1/users/" + targetUserId + "/unfollow";
@@ -351,7 +351,7 @@ namespace Roblox
 		if (!canUseCookie(cookie))
 		{
 			if (outResponse)
-				*outResponse = "Banned cookie";
+				*outResponse = "Banned/warned cookie";
 			return false;
 		}
 		std::string url = "https://www.roblox.com/users/" + targetUserId + "/block";


### PR DESCRIPTION
Extends account filtering logic to treat warned accounts similarly to banned or terminated ones across UI components and backend checks.

Prevents usage and selection of warned accounts, updates status handling and color coding, and ensures consistent messaging and restrictions for warned users.

Improves moderation response handling for increased reliability and clarity.